### PR TITLE
SpringSecurity 적용, Login 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+
+    //security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation group: 'io.jsonwebtoken', name: 'jjwt', version:'0.9.1'
+
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 

--- a/src/main/java/com/blog/som/domain/member/controller/AuthController.java
+++ b/src/main/java/com/blog/som/domain/member/controller/AuthController.java
@@ -1,0 +1,35 @@
+package com.blog.som.domain.member.controller;
+
+import com.blog.som.domain.member.dto.MemberDto;
+import com.blog.som.domain.member.dto.MemberLogin;
+import com.blog.som.domain.member.dto.MemberLogin.Response;
+import com.blog.som.domain.member.dto.TokenResponse;
+import com.blog.som.domain.member.security.service.AuthService;
+import com.blog.som.domain.member.security.token.JwtTokenService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@Api(tags = "인증(Login, Logout, Token 등)")
+@RequiredArgsConstructor
+@RestController
+public class AuthController {
+
+  private final AuthService authService;
+  private final JwtTokenService jwtTokenService;
+
+  @ApiOperation(value = "로그인, JWT token 발행", notes = "accessToken, refreshToken, member 정도 반환")
+  @PostMapping("/login")
+  public ResponseEntity<Response> login(@RequestBody MemberLogin.Request request) {
+
+    MemberDto member = authService.loginMember(request);
+    TokenResponse tokenResponse = jwtTokenService.generateTokenResponse(member.getEmail(), member.getRole());
+
+    return ResponseEntity.ok(new MemberLogin.Response(tokenResponse, member));
+  }
+
+}

--- a/src/main/java/com/blog/som/domain/member/dto/MemberLogin.java
+++ b/src/main/java/com/blog/som/domain/member/dto/MemberLogin.java
@@ -1,0 +1,32 @@
+package com.blog.som.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+public class MemberLogin {
+
+  private MemberLogin(){}
+
+  @Getter
+  @Setter
+  @AllArgsConstructor
+  @Builder
+  public static class Request{
+    private String email;
+    private String password;
+  }
+
+  @Getter
+  @Setter
+  @AllArgsConstructor
+  @NoArgsConstructor
+  @Builder
+  public static class Response{
+    private TokenResponse tokenResponse;
+    private MemberDto member;
+  }
+
+}

--- a/src/main/java/com/blog/som/domain/member/dto/TokenResponse.java
+++ b/src/main/java/com/blog/som/domain/member/dto/TokenResponse.java
@@ -1,0 +1,25 @@
+package com.blog.som.domain.member.dto;
+
+import com.blog.som.domain.member.security.token.TokenConstant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class TokenResponse {
+  private String accessToken;
+  private String refreshToken;
+  private String tokenType;
+
+  public TokenResponse(String accessToken, String refreshToken) {
+    this.accessToken = accessToken;
+    this.refreshToken = refreshToken;
+    this.tokenType = TokenConstant.BEARER;
+  }
+}

--- a/src/main/java/com/blog/som/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/blog/som/domain/member/repository/MemberRepository.java
@@ -1,6 +1,7 @@
 package com.blog.som.domain.member.repository;
 
 import com.blog.som.domain.member.entity.MemberEntity;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,4 +9,6 @@ import org.springframework.stereotype.Repository;
 public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
 
   boolean existsByEmail(String email);
+
+  Optional<MemberEntity> findByEmail(String email);
 }

--- a/src/main/java/com/blog/som/domain/member/security/config/SecurityConfig.java
+++ b/src/main/java/com/blog/som/domain/member/security/config/SecurityConfig.java
@@ -1,0 +1,91 @@
+package com.blog.som.domain.member.security.config;
+
+
+import com.blog.som.domain.member.security.errorhandling.MyAccessDeniedHandler;
+import com.blog.som.domain.member.security.errorhandling.MyAuthenticationEntryPoint;
+import com.blog.som.domain.member.security.filter.JwtAuthenticationFilter;
+import com.blog.som.domain.member.security.filter.JwtExceptionFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+
+@EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+@RequiredArgsConstructor
+@Configuration
+public class SecurityConfig {
+
+  private final JwtAuthenticationFilter jwtAuthenticationFilter;
+  private final JwtExceptionFilter jwtExceptionFilter;
+  private final MyAccessDeniedHandler myAccessDeniedHandler;
+  private final MyAuthenticationEntryPoint myAuthenticationEntryPoint;
+
+  //모두에게 접근 허용
+  private static final String[] PERMIT_ALL_URL = {
+      //swagger
+      "/v2/api-docs",
+      "/swagger-resources/**",
+      "/configuration/ui",
+      "/configuration/security",
+      "/swagger-ui.html",
+      "/swagger-ui/**",
+      "/webjars/**",
+      "/member/register",
+      "/auth/email-auth"
+  };
+
+  //멤버에게만 접근 허용
+  private static final String[] PERMIT_ONLY_MEMBER = {
+      "/member/**"
+  };
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+    http
+        .httpBasic().disable()
+        .csrf().disable()
+        .cors().and()
+        .headers().frameOptions().disable();
+
+    http.formLogin().disable();
+
+    http
+        .authorizeRequests()
+        .antMatchers(PERMIT_ALL_URL)
+        .permitAll()
+        .antMatchers("/admin/**")
+        .hasAuthority("ROLE_ADMIN")
+        .antMatchers(PERMIT_ONLY_MEMBER)
+        .hasAuthority("ROLE_USER");
+
+    http
+        .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+        .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class)
+        .exceptionHandling()
+        .authenticationEntryPoint(myAuthenticationEntryPoint)
+        .accessDeniedHandler(myAccessDeniedHandler);
+
+    return http.build();
+  }
+
+  @Bean
+  public WebSecurityCustomizer webSecurityCustomizer() {
+    return web -> web.ignoring().antMatchers("/login", "/exception/**");
+  }
+
+  @Bean
+  public AuthenticationManager authenticationManager(
+      AuthenticationConfiguration authenticationConfiguration) throws Exception {
+    return authenticationConfiguration.getAuthenticationManager();
+  }
+}

--- a/src/main/java/com/blog/som/domain/member/security/errorhandling/MyAccessDeniedHandler.java
+++ b/src/main/java/com/blog/som/domain/member/security/errorhandling/MyAccessDeniedHandler.java
@@ -1,0 +1,19 @@
+package com.blog.som.domain.member.security.errorhandling;
+
+import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class MyAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException e) throws IOException {
+        log.info("접근 권한이 없습니다. URI : [{}]", request.getRequestURI());
+        response.sendRedirect("/exception/auth-denied");
+    }
+}

--- a/src/main/java/com/blog/som/domain/member/security/errorhandling/MyAuthenticationEntryPoint.java
+++ b/src/main/java/com/blog/som/domain/member/security/errorhandling/MyAuthenticationEntryPoint.java
@@ -1,0 +1,19 @@
+package com.blog.som.domain.member.security.errorhandling;
+
+import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class MyAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        log.info("[로그인이 되지 않았습니다.] MyAuthenticationEntryPoint -> /exception/unauthorized");
+        response.sendRedirect("/exception/unauthorized");
+    }
+}

--- a/src/main/java/com/blog/som/domain/member/security/errorhandling/SecurityExceptionController.java
+++ b/src/main/java/com/blog/som/domain/member/security/errorhandling/SecurityExceptionController.java
@@ -1,0 +1,28 @@
+package com.blog.som.domain.member.security.errorhandling;
+
+import com.blog.som.global.exception.ErrorCode;
+import com.blog.som.global.exception.custom.CustomSecurityException;
+import io.swagger.annotations.ApiOperation;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@Slf4j
+@RestController
+public class SecurityExceptionController {
+
+  @ApiOperation(value = "ACCESS_DENIED 오류 발생 시", notes = "로그인은 되어있으나 접근 권한이 없을 때")
+  @GetMapping("/exception/auth-denied")
+  public void accessDenied() {
+    log.info("ACCESS_DENIED - SecurityController");
+    throw new CustomSecurityException(ErrorCode.ACCESS_DENIED);
+  }
+
+  @ApiOperation(value = "LOGIN_REQUIRED 오류 발생 시", notes = "로그인 되지 않은 상태일 때")
+  @GetMapping("/exception/unauthorized")
+  public void unauthorized() {
+    log.info("LOGIN_REQUIRED - SecurityController");
+    throw new CustomSecurityException(ErrorCode.LOGIN_REQUIRED);
+  }
+}

--- a/src/main/java/com/blog/som/domain/member/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/blog/som/domain/member/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,45 @@
+package com.blog.som.domain.member.security.filter;
+
+import com.blog.som.domain.member.security.token.JwtTokenService;
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Authorization 헤더를 확인해서 Token으로 권한을 확인 후 SecurityContext에 권한을 넣어주는 필터
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+  public static final String TOKEN_HEADER = "Authorization";
+
+  private final JwtTokenService jwtTokenService;
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+    String token = jwtTokenService.resolveTokenFromRequest(request.getHeader(TOKEN_HEADER));
+
+    if (StringUtils.hasText(token) && jwtTokenService.validateToken(token)) {
+      //토큰 유효성 검증 성공
+      Authentication auth = jwtTokenService.getAuthentication(token);
+      SecurityContextHolder.getContext().setAuthentication(auth);
+    } else {
+      log.info("토큰 유효성 검증 실패 !!!");
+    }
+    filterChain.doFilter(request, response);
+  }
+
+
+}

--- a/src/main/java/com/blog/som/domain/member/security/filter/JwtExceptionFilter.java
+++ b/src/main/java/com/blog/som/domain/member/security/filter/JwtExceptionFilter.java
@@ -1,0 +1,53 @@
+package com.blog.som.domain.member.security.filter;
+
+
+import com.blog.som.global.exception.ErrorCode;
+import com.blog.som.global.exception.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import io.jsonwebtoken.JwtException;
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * JWT Exception을 잡아서 Handling 하는 filter setResponse로 직접 응답을 만든다.
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+    try {
+      filterChain.doFilter(request, response);
+    } catch (JwtException e) {
+      String message = e.getMessage();
+      if (message.equals(ErrorCode.JWT_TOKEN_WRONG_TYPE.getDescription())) {
+        setResponse(response, ErrorCode.JWT_TOKEN_WRONG_TYPE);
+      } else if (message.equals(ErrorCode.TOKEN_TIME_OUT.getDescription())) {
+        setResponse(response, ErrorCode.TOKEN_TIME_OUT);
+      }
+    }
+  }
+
+  private void setResponse(HttpServletResponse response, ErrorCode errorCode)
+      throws RuntimeException, IOException {
+    ObjectMapper objectMapper = new JsonMapper();
+    String responseJson = objectMapper.writeValueAsString(new ErrorResponse(errorCode));
+
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE + ";charset=UTF-8");
+    response.setStatus(errorCode.getStatus().value());
+    response.getWriter().print(responseJson);
+  }
+
+}

--- a/src/main/java/com/blog/som/domain/member/security/service/AuthService.java
+++ b/src/main/java/com/blog/som/domain/member/security/service/AuthService.java
@@ -1,0 +1,58 @@
+package com.blog.som.domain.member.security.service;
+
+
+
+import com.blog.som.domain.member.dto.MemberDto;
+import com.blog.som.domain.member.dto.MemberLogin;
+import com.blog.som.domain.member.entity.MemberEntity;
+import com.blog.som.domain.member.repository.MemberRepository;
+import com.blog.som.domain.member.security.userdetails.LoginMember;
+import com.blog.som.domain.member.type.Role;
+import com.blog.som.global.components.mail.MailSender;
+import com.blog.som.global.components.mail.SendMailDto;
+import com.blog.som.global.components.password.PasswordUtils;
+import com.blog.som.global.exception.ErrorCode;
+import com.blog.som.global.exception.custom.MemberException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class AuthService implements UserDetailsService {
+
+  private final MemberRepository memberRepository;
+  private final MailSender mailSender;
+
+  public MemberDto loginMember(MemberLogin.Request input) {
+    MemberEntity member = memberRepository.findByEmail(input.getEmail())
+        .orElseThrow(() -> new MemberException(ErrorCode.LOGIN_FAILED_USER_NOT_FOUND));
+
+    //비밀번호 확인
+    if (!PasswordUtils.equalsPlainTextAndHashed(input.getPassword(), member.getPassword())) {
+      throw new MemberException(ErrorCode.LOGIN_FAILED_PASSWORD_INCORRECT);
+    }
+
+    //UNAUTH 상태일 시 예외 발생
+    if (Role.UNAUTH.equals(member.getRole())) {
+      mailSender.sendMailForRegister(new SendMailDto(member));
+      throw new MemberException(ErrorCode.EMAIL_AUTH_REQUIRED);
+    }
+
+    return MemberDto.fromEntity(member);
+  }
+
+
+  @Override
+  public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+    MemberEntity member = memberRepository.findByEmail(username)
+        .orElseThrow(() -> new UsernameNotFoundException("회원 정보가 존재하지 않습니다."));
+    log.info("인증 성공[ ID : {} ]", member.getEmail());
+
+    return new LoginMember(member);
+  }
+}

--- a/src/main/java/com/blog/som/domain/member/security/service/AuthService.java
+++ b/src/main/java/com/blog/som/domain/member/security/service/AuthService.java
@@ -28,12 +28,12 @@ public class AuthService implements UserDetailsService {
   private final MemberRepository memberRepository;
   private final MailSender mailSender;
 
-  public MemberDto loginMember(MemberLogin.Request input) {
-    MemberEntity member = memberRepository.findByEmail(input.getEmail())
-        .orElseThrow(() -> new MemberException(ErrorCode.LOGIN_FAILED_USER_NOT_FOUND));
+  public MemberDto loginMember(MemberLogin.Request loginInput) {
+    MemberEntity member = memberRepository.findByEmail(loginInput.getEmail())
+        .orElseThrow(() -> new MemberException(ErrorCode.LOGIN_FAILED_MEMBER_NOT_FOUND));
 
     //비밀번호 확인
-    if (!PasswordUtils.equalsPlainTextAndHashed(input.getPassword(), member.getPassword())) {
+    if (!PasswordUtils.equalsPlainTextAndHashed(loginInput.getPassword(), member.getPassword())) {
       throw new MemberException(ErrorCode.LOGIN_FAILED_PASSWORD_INCORRECT);
     }
 
@@ -50,7 +50,7 @@ public class AuthService implements UserDetailsService {
   @Override
   public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
     MemberEntity member = memberRepository.findByEmail(username)
-        .orElseThrow(() -> new UsernameNotFoundException("회원 정보가 존재하지 않습니다."));
+        .orElseThrow(() -> new UsernameNotFoundException(ErrorCode.MEMBER_NOT_FOUND.getDescription()));
     log.info("인증 성공[ ID : {} ]", member.getEmail());
 
     return new LoginMember(member);

--- a/src/main/java/com/blog/som/domain/member/security/token/JwtTokenService.java
+++ b/src/main/java/com/blog/som/domain/member/security/token/JwtTokenService.java
@@ -1,0 +1,106 @@
+package com.blog.som.domain.member.security.token;
+
+import static com.blog.som.domain.member.security.token.TokenConstant.ACCESS_TOKEN_EXPIRE_TIME;
+import static com.blog.som.domain.member.security.token.TokenConstant.BEARER;
+import static com.blog.som.domain.member.security.token.TokenConstant.KEY_ROLES;
+import static com.blog.som.domain.member.security.token.TokenConstant.REFRESH_TOKEN_EXPIRE_TIME;
+
+import com.blog.som.domain.member.dto.TokenResponse;
+import com.blog.som.domain.member.security.service.AuthService;
+import com.blog.som.domain.member.type.Role;
+import com.blog.som.global.exception.ErrorCode;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.SignatureException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtTokenService {
+
+  private final AuthService authService;
+
+  @Value("${spring.jwt.secret}")
+  private String secretKey;
+
+  public TokenResponse generateTokenResponse(String email, Role role) {
+    Claims claims = Jwts.claims().setSubject(email);
+    claims.put(KEY_ROLES, this.getRoles(role));
+
+    String accessToken = this.generateToken(claims, ACCESS_TOKEN_EXPIRE_TIME);
+    String refreshToken = this.generateToken(claims, REFRESH_TOKEN_EXPIRE_TIME);
+
+    return new TokenResponse(accessToken, refreshToken);
+  }
+
+  private String generateToken(Claims claims, long expiredTime) {
+    Date now = new Date();
+    Date expired = new Date(now.getTime() + expiredTime);
+    return Jwts.builder()
+        .setClaims(claims)
+        .setIssuedAt(now)
+        .setExpiration(expired)
+        .signWith(SignatureAlgorithm.HS512, this.secretKey)
+        .compact();
+  }
+
+  private List<String> getRoles(Role role) {
+    List<String> roles = new ArrayList<>();
+    roles.add("ROLE_" + role);
+    return roles;
+  }
+
+  public String resolveTokenFromRequest(String token) {
+    if (StringUtils.hasText(token) && token.startsWith(BEARER)) {
+      log.info("resolve complete");
+      return token.substring(BEARER.length());
+    }
+    log.info("resolve fail");
+    return null;
+  }
+
+  public boolean validateToken(String token) {
+    if (!StringUtils.hasText(token)) {
+      return false;
+    }
+    //token의 만료 시간이 현재시간 보다 이후 일 때 true 반환
+    return this.parseClaims(token).getExpiration().after(new Date());
+  }
+
+  public Authentication getAuthentication(String token) {
+    String username = this.parseClaims(token).getSubject();
+    UserDetails userDetails = authService.loadUserByUsername(username);
+    return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+  }
+
+  /**
+   * 토큰이 유효한지 확인
+   */
+  private Claims parseClaims(String token) {
+    try {
+      return Jwts.parser().setSigningKey(this.secretKey).parseClaimsJws(token).getBody();
+    } catch (ExpiredJwtException e) {
+      throw new JwtException(ErrorCode.TOKEN_TIME_OUT.getDescription());
+    } catch (SignatureException e) {
+      throw new JwtException(ErrorCode.JWT_TOKEN_WRONG_TYPE.getDescription());
+    } catch (MalformedJwtException e) {
+      throw new JwtException(ErrorCode.JWT_TOKEN_MALFORMED.getDescription());
+    }
+  }
+
+}

--- a/src/main/java/com/blog/som/domain/member/security/token/TokenConstant.java
+++ b/src/main/java/com/blog/som/domain/member/security/token/TokenConstant.java
@@ -1,0 +1,16 @@
+package com.blog.som.domain.member.security.token;
+
+public class TokenConstant {
+
+  private TokenConstant(){}
+
+  public static final String BEARER = "Bearer ";
+
+  public static final String KEY_ROLES = "roles";
+
+  public static final long ACCESS_TOKEN_EXPIRE_TIME = (long) 1000 * 60 * 60 * 24;// 24시간 (실제로는 30분정도로 수정해야함)
+
+  public static final long REFRESH_TOKEN_EXPIRE_TIME = (long) 1000 * 60 * 60 * 24 * 30;// 한 달
+
+
+}

--- a/src/main/java/com/blog/som/domain/member/security/userdetails/LoginMember.java
+++ b/src/main/java/com/blog/som/domain/member/security/userdetails/LoginMember.java
@@ -1,0 +1,65 @@
+package com.blog.som.domain.member.security.userdetails;
+
+
+import com.blog.som.domain.member.entity.MemberEntity;
+import com.blog.som.domain.member.type.Role;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import lombok.Data;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Data
+public class LoginMember implements UserDetails {
+
+  private Long memberId;
+  private String email;
+  private String password;
+  private Role role;
+
+  public LoginMember(MemberEntity member) {
+    this.memberId = member.getMemberId();
+    this.email = member.getEmail();
+    this.password = member.getPassword();
+    this.role = member.getRole();
+  }
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    List<GrantedAuthority> grantedAuthorities = new ArrayList<>();
+    grantedAuthorities.add(new SimpleGrantedAuthority("ROLE_" + this.role));
+    return grantedAuthorities;
+  }
+
+  @Override
+  public String getPassword() {
+    return this.password;
+  }
+
+  @Override
+  public String getUsername() {
+    return this.email;
+  }
+
+  @Override
+  public boolean isAccountNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isAccountNonLocked() {
+    return true;
+  }
+
+  @Override
+  public boolean isCredentialsNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return true;
+  }
+}

--- a/src/main/java/com/blog/som/domain/member/security/userdetails/LoginMember.java
+++ b/src/main/java/com/blog/som/domain/member/security/userdetails/LoginMember.java
@@ -11,7 +11,17 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
-@Data
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
 public class LoginMember implements UserDetails {
 
   private Long memberId;

--- a/src/main/java/com/blog/som/global/components/mail/MailSender.java
+++ b/src/main/java/com/blog/som/global/components/mail/MailSender.java
@@ -1,5 +1,6 @@
 package com.blog.som.global.components.mail;
 
+import com.blog.som.global.redis.email.EmailAuthRepository;
 import javax.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,9 +13,10 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @RequiredArgsConstructor
 @Component
-public class MailComponent {
+public class MailSender {
 
   private final JavaMailSender javaMailSender;
+  private final EmailAuthRepository emailAuthRepository;
 
   @Async
   public void sendMailForRegister(SendMailDto sendMailDto) {
@@ -28,7 +30,10 @@ public class MailComponent {
         .append("<p>감사합니다!</p>")
         .toString();
 
-    sendMail(mail, subject, text);
+    //Redis 에 저장 (timeout = 10분)
+    emailAuthRepository.saveEmailAuthUuid(sendMailDto.getAuthKey(), sendMailDto.getEmail());
+
+    this.sendMail(mail, subject, text);
     log.info("메일 전송 완료 - {}", mail);
   }
 

--- a/src/main/java/com/blog/som/global/components/mail/SendMailDto.java
+++ b/src/main/java/com/blog/som/global/components/mail/SendMailDto.java
@@ -1,5 +1,7 @@
 package com.blog.som.global.components.mail;
 
+import com.blog.som.domain.member.entity.MemberEntity;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -11,4 +13,10 @@ public class SendMailDto {
     private String email;
     private String nickname;
     private String authKey;
+
+    public SendMailDto(MemberEntity member) {
+        this.email = member.getEmail();
+        this.nickname = member.getNickname();
+        this.authKey = UUID.randomUUID().toString();
+    }
 }

--- a/src/main/java/com/blog/som/global/components/password/PasswordUtils.java
+++ b/src/main/java/com/blog/som/global/components/password/PasswordUtils.java
@@ -1,5 +1,6 @@
 package com.blog.som.global.components.password;
 
+import org.springframework.security.crypto.bcrypt.BCrypt;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -7,11 +8,21 @@ public class PasswordUtils {
 
   private PasswordUtils(){}
 
+  public static boolean equalsPlainTextAndHashed(String plainText, String hashed) {
+    if (plainText == null || plainText.isEmpty()) {
+      return false;
+    }
+    if (hashed == null || hashed.isEmpty()) {
+      return false;
+    }
+
+    return BCrypt.checkpw(plainText, hashed);
+  }
+
   public static String encPassword(String plainText) {
     if (plainText == null || plainText.isEmpty()) {
       return "";
     }
-    //TODO : Password Encoding
-    return plainText;
+    return BCrypt.hashpw(plainText, BCrypt.gensalt());
   }
 }

--- a/src/main/java/com/blog/som/global/exception/ErrorCode.java
+++ b/src/main/java/com/blog/som/global/exception/ErrorCode.java
@@ -18,7 +18,7 @@ public enum ErrorCode {
 
 
   //Security
-  LOGIN_FAILED_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "계정이 존재하지 않습니다."),
+  LOGIN_FAILED_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "계정이 존재하지 않습니다."),
   LOGIN_FAILED_PASSWORD_INCORRECT(HttpStatus.UNAUTHORIZED, "비밀번호가 틀립니다."),
   ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
   LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, "로그인이 되지 않았습니다."),

--- a/src/main/java/com/blog/som/global/exception/ErrorCode.java
+++ b/src/main/java/com/blog/som/global/exception/ErrorCode.java
@@ -13,15 +13,29 @@ public enum ErrorCode {
   EMAIL_AUTH_TIME_OUT(HttpStatus.NOT_FOUND, "이메일 인증 키가 만료되었거나, 잘못된 요청 입니다."),
   EMAIL_AUTH_WRONG_KEY(HttpStatus.NOT_FOUND, "이메일 인증 키에 문제가 있습니다."),
   EMAIL_AUTH_ALREADY_COMPLETE(HttpStatus.NOT_FOUND, "이미 이메일 인증 완료 된 회원입니다."),
+  EMAIL_AUTH_REQUIRED(HttpStatus.NOT_FOUND, "이메일 인증이 완료되지 않았습니다. 다시 이메일이 발송되었습니다."),
 
 
+
+  //Security
+  LOGIN_FAILED_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "계정이 존재하지 않습니다."),
+  LOGIN_FAILED_PASSWORD_INCORRECT(HttpStatus.UNAUTHORIZED, "비밀번호가 틀립니다."),
+  ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+  LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, "로그인이 되지 않았습니다."),
+
+  JWT_REFRESH_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 RefreshToken 입니다. 다시 로그인 해주세요."),
+  JWT_TOKEN_ALREADY_LOGGED_OUT(HttpStatus.UNAUTHORIZED, "로그아웃된 인증 정보입니다."),
+  TOKEN_TIME_OUT(HttpStatus.FORBIDDEN, "토큰이 만료되었습니다."),
+  JWT_TOKEN_WRONG_TYPE(HttpStatus.FORBIDDEN, "JWT 토큰 형식에 문제가 있습니다."),
+  JWT_TOKEN_MALFORMED(HttpStatus.FORBIDDEN, "JWT 토큰이 변조되었습니다."),
+  NO_JWT_TOKEN(HttpStatus.FORBIDDEN, "JWT 토큰이 존재하지 않습니다."),
 
 
   //global
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 오류가 발생 했습니다.");
 
 
-  private final HttpStatus statusCode;
+  private final HttpStatus status;
   private final String description;
 
 }

--- a/src/main/java/com/blog/som/global/exception/ErrorResponse.java
+++ b/src/main/java/com/blog/som/global/exception/ErrorResponse.java
@@ -10,13 +10,13 @@ public class ErrorResponse {
   private String errorMessage;
 
   public ErrorResponse(ErrorCode errorCode) {
-    this.statusCode = errorCode.getStatusCode().value();
+    this.statusCode = errorCode.getStatus().value();
     this.errorCode = errorCode;
     this.errorMessage = errorCode.getDescription();
   }
 
   public ErrorResponse(ErrorCode errorCode, String errorMessage) {
-    this.statusCode = errorCode.getStatusCode().value();
+    this.statusCode = errorCode.getStatus().value();
     this.errorCode = errorCode;
     this.errorMessage = errorMessage;
   }

--- a/src/main/java/com/blog/som/global/exception/custom/CustomSecurityException.java
+++ b/src/main/java/com/blog/som/global/exception/custom/CustomSecurityException.java
@@ -1,0 +1,23 @@
+package com.blog.som.global.exception.custom;
+
+import com.blog.som.global.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+public class CustomSecurityException extends RuntimeException{
+    private ErrorCode errorCode;
+    private String errorMessage;
+
+    public CustomSecurityException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+        this.errorMessage = errorCode.getDescription();
+    }
+}

--- a/src/main/java/com/blog/som/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/blog/som/global/exception/handler/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.blog.som.global.exception.handler;
 import com.blog.som.global.exception.ErrorCode;
 import com.blog.som.global.exception.ErrorResponse;
 import com.blog.som.global.exception.custom.MemberException;
+import com.blog.som.global.exception.custom.CustomSecurityException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -16,13 +17,19 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ErrorResponse> handleException(Exception e) {
     ErrorResponse errorResponse = new ErrorResponse(ErrorCode.INTERNAL_SERVER_ERROR,
         e.getMessage());
-    return new ResponseEntity<>(errorResponse, errorResponse.getErrorCode().getStatusCode());
+    return new ResponseEntity<>(errorResponse, errorResponse.getErrorCode().getStatus());
   }
 
   @ExceptionHandler(MemberException.class)
   public ResponseEntity<ErrorResponse> handleMemberException(MemberException e) {
     ErrorResponse errorResponse = new ErrorResponse(e.getErrorCode(), e.getErrorMessage());
-    return new ResponseEntity<>(errorResponse, e.getErrorCode().getStatusCode());
+    return new ResponseEntity<>(errorResponse, e.getErrorCode().getStatus());
+  }
+
+  @ExceptionHandler(CustomSecurityException.class)
+  public ResponseEntity<ErrorResponse> handleSecurityException(CustomSecurityException e) {
+    ErrorResponse errorResponse = new ErrorResponse(e.getErrorCode(), e.getErrorMessage());
+    return new ResponseEntity<>(errorResponse, e.getErrorCode().getStatus());
   }
 
 }

--- a/src/main/java/com/blog/som/global/redis/email/EmailAuthRedisRepository.java
+++ b/src/main/java/com/blog/som/global/redis/email/EmailAuthRedisRepository.java
@@ -19,13 +19,13 @@ public class EmailAuthRedisRepository implements EmailAuthRepository{
 
 
   @Override
-  public void saveEmailAuthUuid(String uuid, Long id) {
+  public void saveEmailAuthUuid(String uuid, String email) {
     ValueOperations<String, String> emailAuths = redisTemplate.opsForValue();
-    emailAuths.set(uuid, String.valueOf(id), Duration.ofMinutes(TimeConstant.EMAIL_AUTH_MINUTE));
+    emailAuths.set(uuid, email, Duration.ofMinutes(TimeConstant.EMAIL_AUTH_MINUTE));
   }
 
   @Override
-  public Long getEmailAuthMemberId(String uuid) {
+  public String getEmailByUuid(String uuid) {
     ValueOperations<String, String> emailAuths = redisTemplate.opsForValue();
 
     if(Boolean.FALSE.equals(redisTemplate.hasKey(uuid))){
@@ -33,7 +33,7 @@ public class EmailAuthRedisRepository implements EmailAuthRepository{
       throw new MemberException(ErrorCode.EMAIL_AUTH_TIME_OUT);
     }
 
-    return Long.valueOf(emailAuths.get(uuid));
+    return emailAuths.get(uuid);
   }
 
 }

--- a/src/main/java/com/blog/som/global/redis/email/EmailAuthRepository.java
+++ b/src/main/java/com/blog/som/global/redis/email/EmailAuthRepository.java
@@ -2,7 +2,7 @@ package com.blog.som.global.redis.email;
 
 public interface EmailAuthRepository {
 
-  void saveEmailAuthUuid(String uuid, Long id);
+  void saveEmailAuthUuid(String uuid, String email);
 
-  Long getEmailAuthMemberId(String uuid);
+  String getEmailByUuid(String uuid);
 }

--- a/src/test/java/com/blog/som/EntityCreator.java
+++ b/src/test/java/com/blog/som/EntityCreator.java
@@ -1,0 +1,22 @@
+package com.blog.som;
+
+import com.blog.som.domain.member.entity.MemberEntity;
+import com.blog.som.domain.member.type.Role;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class EntityCreator {
+
+  public static MemberEntity createMember(Long id) {
+    return MemberEntity.builder()
+        .memberId(id)
+        .email("test" + id + "@test.com")
+        .password("password" + id)
+        .nickname("nickname" + id)
+        .phoneNumber("010" + id + "00" + "5678")
+        .birthDate(LocalDate.now())
+        .registeredAt(LocalDateTime.now())
+        .role(Role.USER)
+        .build();
+  }
+}

--- a/src/test/java/com/blog/som/domain/member/security/service/AuthServiceTest.java
+++ b/src/test/java/com/blog/som/domain/member/security/service/AuthServiceTest.java
@@ -1,0 +1,178 @@
+package com.blog.som.domain.member.security.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import com.blog.som.EntityCreator;
+import com.blog.som.domain.member.dto.MemberDto;
+import com.blog.som.domain.member.dto.MemberLogin;
+import com.blog.som.domain.member.dto.MemberLogin.Request;
+import com.blog.som.domain.member.entity.MemberEntity;
+import com.blog.som.domain.member.repository.MemberRepository;
+import com.blog.som.domain.member.type.Role;
+import com.blog.som.global.components.mail.MailSender;
+import com.blog.som.global.components.password.PasswordUtils;
+import com.blog.som.global.exception.ErrorCode;
+import com.blog.som.global.exception.custom.MemberException;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+@Slf4j
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+  @Mock
+  private MemberRepository memberRepository;
+  @Mock
+  private MailSender mailSender;
+
+  @InjectMocks
+  private AuthService authService;
+
+
+  @Nested
+  @DisplayName("로그인")
+  class LoginMember {
+
+    @Test
+    @DisplayName("성공")
+    void loginMember() {
+      MemberEntity member = EntityCreator.createMember(1L);
+      String plainPassword = member.getPassword();
+      String encPassword = PasswordUtils.encPassword(member.getPassword());
+      member.setPassword(encPassword);
+
+      Request loginInput = Request.builder()
+          .email(member.getEmail())
+          .password(plainPassword)
+          .build();
+      //given
+      when(memberRepository.findByEmail(member.getEmail()))
+          .thenReturn(Optional.of(member));
+
+      //when
+      MemberDto result = authService.loginMember(loginInput);
+
+      //then
+      assertThat(member.getMemberId()).isEqualTo(result.getMemberId());
+      assertThat(member.getEmail()).isEqualTo(result.getEmail());
+      assertThat(result.getRole()).isEqualTo(Role.USER);
+    }
+
+    @Test
+    @DisplayName("실패 : LOGIN_FAILED_MEMBER_NOT_FOUND")
+    void loginMember_LOGIN_FAILED_MEMBER_NOT_FOUND() {
+      MemberEntity member = EntityCreator.createMember(1L);
+      Request loginInput = Request.builder()
+          .email(member.getEmail())
+          .password(member.getPassword())
+          .build();
+      //given
+      when(memberRepository.findByEmail(member.getEmail()))
+          .thenReturn(Optional.empty());
+
+      //when
+      //then
+      MemberException memberException = assertThrows(MemberException.class, () -> authService.loginMember(loginInput));
+      assertThat(memberException.getErrorCode()).isEqualTo(ErrorCode.LOGIN_FAILED_MEMBER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("실패 : LOGIN_FAILED_PASSWORD_INCORRECT")
+    void loginMember_LOGIN_FAILED_PASSWORD_INCORRECT() {
+      MemberEntity member = EntityCreator.createMember(1L);
+      String plainPassword = member.getPassword();
+      String encPassword = PasswordUtils.encPassword(member.getPassword()+"!!!");
+      member.setPassword(encPassword);
+
+      Request loginInput = Request.builder()
+          .email(member.getEmail())
+          .password(plainPassword)
+          .build();
+      //given
+      when(memberRepository.findByEmail(member.getEmail()))
+          .thenReturn(Optional.of(member));
+
+      //when
+      //then
+      MemberException memberException = assertThrows(MemberException.class, () -> authService.loginMember(loginInput));
+      assertThat(memberException.getErrorCode()).isEqualTo(ErrorCode.LOGIN_FAILED_PASSWORD_INCORRECT);
+    }
+
+    @Test
+    @DisplayName("실패 : EMAIL_AUTH_REQUIRED")
+    void loginMember_EMAIL_AUTH_REQUIRED() {
+      MemberEntity member = EntityCreator.createMember(1L);
+      String plainPassword = member.getPassword();
+      String encPassword = PasswordUtils.encPassword(member.getPassword());
+      member.setPassword(encPassword);
+      member.setRole(Role.UNAUTH);
+
+      Request loginInput = Request.builder()
+          .email(member.getEmail())
+          .password(plainPassword)
+          .build();
+      //given
+      when(memberRepository.findByEmail(member.getEmail()))
+          .thenReturn(Optional.of(member));
+
+      //when
+      //then
+      MemberException memberException = assertThrows(MemberException.class, () -> authService.loginMember(loginInput));
+      assertThat(memberException.getErrorCode()).isEqualTo(ErrorCode.EMAIL_AUTH_REQUIRED);
+    }
+
+  }
+
+
+  @Nested
+  @DisplayName("loadUserByUsername")
+  class LoadUserByUsername{
+    @Test
+    @DisplayName("성공")
+    void loadUserByUsername(){
+      MemberEntity member = EntityCreator.createMember(1L);
+      String username = member.getEmail();
+      //given
+      when(memberRepository.findByEmail(username))
+          .thenReturn(Optional.of(member));
+
+      //when
+      UserDetails userDetails = authService.loadUserByUsername(username);
+
+      //then
+      assertThat(userDetails.getUsername()).isEqualTo(username);
+      assertThat(userDetails.getPassword()).isEqualTo(member.getPassword());
+
+
+    }
+
+    @Test
+    @DisplayName("실패 : UsernameNotFoundException")
+    void loadUserByUsername_UsernameNotFoundException(){
+      MemberEntity member = EntityCreator.createMember(1L);
+      String username = member.getEmail();
+      //given
+      when(memberRepository.findByEmail(username))
+          .thenReturn(Optional.empty());
+
+      //when
+      //then
+      UsernameNotFoundException usernameNotFoundException =
+          assertThrows(UsernameNotFoundException.class, () -> authService.loadUserByUsername(username));
+      assertThat(usernameNotFoundException.getMessage()).isEqualTo(ErrorCode.MEMBER_NOT_FOUND.getDescription());
+    }
+  }
+}

--- a/src/test/java/com/blog/som/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/blog/som/domain/member/service/MemberServiceTest.java
@@ -14,7 +14,7 @@ import com.blog.som.domain.member.dto.MemberRegister.Response;
 import com.blog.som.domain.member.entity.MemberEntity;
 import com.blog.som.domain.member.repository.MemberRepository;
 import com.blog.som.domain.member.type.Role;
-import com.blog.som.global.components.mail.MailComponent;
+import com.blog.som.global.components.mail.MailSender;
 import com.blog.som.global.components.password.PasswordUtils;
 import com.blog.som.global.constant.ResponseConstant;
 import com.blog.som.global.exception.ErrorCode;
@@ -41,7 +41,7 @@ class MemberServiceTest {
   @Mock
   private EmailAuthRepository emailAuthRepository;
   @Mock
-  private MailComponent mailComponent;
+  private MailSender mailSender;
 
 
   @InjectMocks
@@ -126,9 +126,9 @@ class MemberServiceTest {
       member.setRole(Role.UNAUTH);
 
       //given
-      when(emailAuthRepository.getEmailAuthMemberId(testUUID))
-          .thenReturn(1L);
-      when(memberRepository.findById(1L))
+      when(emailAuthRepository.getEmailByUuid(testUUID))
+          .thenReturn(member.getEmail());
+      when(memberRepository.findByEmail(member.getEmail()))
           .thenReturn(Optional.of(member));
 
       //when
@@ -148,9 +148,9 @@ class MemberServiceTest {
       member.setRole(Role.USER);
 
       //given
-      when(emailAuthRepository.getEmailAuthMemberId(testUUID))
-          .thenReturn(1L);
-      when(memberRepository.findById(1L))
+      when(emailAuthRepository.getEmailByUuid(testUUID))
+          .thenReturn(member.getEmail());
+      when(memberRepository.findByEmail(member.getEmail()))
           .thenReturn(Optional.of(member));
 
       //when

--- a/src/test/java/com/blog/som/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/blog/som/domain/member/service/MemberServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.blog.som.EntityCreator;
 import com.blog.som.domain.member.dto.EmailAuthResult;
 import com.blog.som.domain.member.dto.MemberRegister;
 import com.blog.som.domain.member.dto.MemberRegister.Request;
@@ -47,18 +48,6 @@ class MemberServiceTest {
   @InjectMocks
   private MemberServiceImpl memberService;
 
-  private MemberEntity createMember(Long id) {
-    return MemberEntity.builder()
-        .memberId(id)
-        .email("test" + id + "@test.com")
-        .password("password" + id)
-        .nickname("nickname" + id)
-        .phoneNumber("010" + id + "00" + "5678")
-        .birthDate(LocalDate.now())
-        .registeredAt(LocalDateTime.now())
-        .role(Role.USER)
-        .build();
-  }
 
   @Nested
   @DisplayName("회원 가입")
@@ -78,7 +67,7 @@ class MemberServiceTest {
     @DisplayName("성공")
     void registerMember() {
       //given
-      MemberEntity member = createMember(1L);
+      MemberEntity member = EntityCreator.createMember(1L);
       Request request = this.createRequest(member);
 
       when(memberRepository.existsByEmail(request.getEmail()))
@@ -100,7 +89,7 @@ class MemberServiceTest {
     @DisplayName("MEMBER_ALREADY_EXISTS")
     void registerMember_MEMBER_ALREADY_EXISTS() {
       //given
-      MemberEntity member = createMember(1L);
+      MemberEntity member = EntityCreator.createMember(1L);
       Request request = this.createRequest(member);
 
       when(memberRepository.existsByEmail(request.getEmail()))
@@ -122,7 +111,7 @@ class MemberServiceTest {
     @Test
     @DisplayName("성공 - 이메일 인증 완료")
     void emailAuth() {
-      MemberEntity member = createMember(1L);
+      MemberEntity member = EntityCreator.createMember(1L);
       member.setRole(Role.UNAUTH);
 
       //given
@@ -144,7 +133,7 @@ class MemberServiceTest {
     @Test
     @DisplayName("실패 - 이미 인증 완료된 유저")
     void emailAuth_EMAIL_AUTH_ALREADY_COMPLETED() {
-      MemberEntity member = createMember(1L);
+      MemberEntity member = EntityCreator.createMember(1L);
       member.setRole(Role.USER);
 
       //given


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요.  -->
### [MailSender 변경 사항]
- MailComponent -> MailSender 클래스 명 변경
- sendMailForRegister 메서드에 uuid를 Redis에 저장하는 로직 추가
- Redis에 `Key=UUID, value=memberId`를 저장하던 것에서, `value = email`을 저장하는 것으로 수정

### [Spring Security]
- Spring Security 적용
- login된 멤버는 `@AuthenticationPrincipal LoginMember loginMember`를 통해 사용할 수 있다.
    - `LoginMember`는 UserDetails를 구현한 Principal을 담고있는 클래스이다.
- Security Config 
    - PERMIT_ALL_URL : 모든 유저에게 open 된 url
    - PERMIT_ONLY_MEMBER : 회원에게만 open된 uri ( 점차 다른 uri 들을 추가 할 예정 )
 - AccessDeniedHandler `/exception/auth-denied` : 접근 권한이 없을 때
 - AuthenticationEntryPoint `/exception/unauthorized` : 로그인이 되지 않았을 때
 - JwtTokenService.parseClaim(String token) 에서 발생하는 예외
     - ExpiredJwtException : 토큰이 만료되었을 때
     - SignatureException : 토큰 형식이 잘못되었을 때
     - MalformedJwtException : 토큰이 변조되었을 때
    

### [로그인]
- 로그인 시 ID, 비밀번호를 입력 받는다.
- 예외 발생 없이 `authService.loginMember()`으로 `MemberDto`를 반환
- 반환받은 Member 정보로 token을 발행하여 `TokenResponse`를 반환한다.
- `TokenResponse`와 `MemberDto`를 담은 `MemberLogin.Response`를 클라이언트 측에 반환한다.
---

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 

