### PR TITLE
로그아웃 api

### DIFF
--- a/src/main/java/com/blog/som/domain/member/controller/AuthController.java
+++ b/src/main/java/com/blog/som/domain/member/controller/AuthController.java
@@ -2,7 +2,6 @@ package com.blog.som.domain.member.controller;
 
 import com.blog.som.domain.member.dto.MemberDto;
 import com.blog.som.domain.member.dto.MemberLogin;
-import com.blog.som.domain.member.dto.MemberLogin.Response;
 import com.blog.som.domain.member.dto.MemberLogoutResponse;
 import com.blog.som.domain.member.dto.TokenResponse;
 import com.blog.som.domain.member.security.service.AuthService;
@@ -26,12 +25,15 @@ public class AuthController {
   private final AuthService authService;
   private final JwtTokenService jwtTokenService;
 
-  @ApiOperation(value = "로그인, JWT token 발행", notes = "accessToken, refreshToken, member 정도 반환")
+  @ApiOperation(value = "로그인, JWT token 발행", notes = "accessToken, refreshToken, member 정보 반환")
   @PostMapping("/login")
-  public ResponseEntity<Response> login(@RequestBody MemberLogin.Request request) {
+  public ResponseEntity<MemberLogin.Response> login(@RequestBody MemberLogin.Request request) {
 
     MemberDto member = authService.loginMember(request);
+
     TokenResponse tokenResponse = jwtTokenService.generateTokenResponse(member.getEmail(), member.getRole());
+
+    authService.saveRefreshToken(member.getEmail(), tokenResponse.getRefreshToken());
 
     return ResponseEntity.ok(new MemberLogin.Response(tokenResponse, member));
   }

--- a/src/main/java/com/blog/som/domain/member/controller/AuthController.java
+++ b/src/main/java/com/blog/som/domain/member/controller/AuthController.java
@@ -3,15 +3,19 @@ package com.blog.som.domain.member.controller;
 import com.blog.som.domain.member.dto.MemberDto;
 import com.blog.som.domain.member.dto.MemberLogin;
 import com.blog.som.domain.member.dto.MemberLogin.Response;
+import com.blog.som.domain.member.dto.MemberLogoutResponse;
 import com.blog.som.domain.member.dto.TokenResponse;
 import com.blog.som.domain.member.security.service.AuthService;
 import com.blog.som.domain.member.security.token.JwtTokenService;
+import com.blog.som.domain.member.security.userdetails.LoginMember;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 @Api(tags = "인증(Login, Logout, Token 등)")
@@ -30,6 +34,18 @@ public class AuthController {
     TokenResponse tokenResponse = jwtTokenService.generateTokenResponse(member.getEmail(), member.getRole());
 
     return ResponseEntity.ok(new MemberLogin.Response(tokenResponse, member));
+  }
+
+  @ApiOperation(value = "로그아웃", notes = "accessToken blacklist 처리")
+  @PostMapping("/logout")
+  public ResponseEntity<MemberLogoutResponse> logout(
+      @AuthenticationPrincipal LoginMember loginMember,
+      @RequestHeader("Authorization") String bearerToken) {
+
+    MemberLogoutResponse memberLogoutResponse =
+        authService.logoutMember(loginMember.getEmail(), jwtTokenService.resolveTokenFromRequest(bearerToken));
+
+    return ResponseEntity.ok(memberLogoutResponse);
   }
 
 }

--- a/src/main/java/com/blog/som/domain/member/dto/MemberLogoutResponse.java
+++ b/src/main/java/com/blog/som/domain/member/dto/MemberLogoutResponse.java
@@ -1,0 +1,18 @@
+package com.blog.som.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class MemberLogoutResponse {
+
+  private String email;
+  private boolean logoutResult;
+}

--- a/src/main/java/com/blog/som/domain/member/security/config/SecurityConfig.java
+++ b/src/main/java/com/blog/som/domain/member/security/config/SecurityConfig.java
@@ -80,7 +80,7 @@ public class SecurityConfig {
 
   @Bean
   public WebSecurityCustomizer webSecurityCustomizer() {
-    return web -> web.ignoring().antMatchers("/login", "/exception/**");
+    return web -> web.ignoring().antMatchers("/login", "/logout", "/exception/**");
   }
 
   @Bean

--- a/src/main/java/com/blog/som/domain/member/security/service/AuthService.java
+++ b/src/main/java/com/blog/som/domain/member/security/service/AuthService.java
@@ -4,6 +4,7 @@ package com.blog.som.domain.member.security.service;
 
 import com.blog.som.domain.member.dto.MemberDto;
 import com.blog.som.domain.member.dto.MemberLogin;
+import com.blog.som.domain.member.dto.MemberLogoutResponse;
 import com.blog.som.domain.member.entity.MemberEntity;
 import com.blog.som.domain.member.repository.MemberRepository;
 import com.blog.som.domain.member.security.userdetails.LoginMember;
@@ -13,6 +14,7 @@ import com.blog.som.global.components.mail.SendMailDto;
 import com.blog.som.global.components.password.PasswordUtils;
 import com.blog.som.global.exception.ErrorCode;
 import com.blog.som.global.exception.custom.MemberException;
+import com.blog.som.global.redis.token.TokenRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -27,6 +29,7 @@ public class AuthService implements UserDetailsService {
 
   private final MemberRepository memberRepository;
   private final MailSender mailSender;
+  private final TokenRepository tokenRepository;
 
   public MemberDto loginMember(MemberLogin.Request loginInput) {
     MemberEntity member = memberRepository.findByEmail(loginInput.getEmail())
@@ -44,6 +47,15 @@ public class AuthService implements UserDetailsService {
     }
 
     return MemberDto.fromEntity(member);
+  }
+
+  public MemberLogoutResponse logoutMember(String email, String accessToken){
+    //accessToken blacklist 추가
+    tokenRepository.addBlacklistAccessToken(accessToken, email);
+    //refreshToken 삭제
+    boolean result = tokenRepository.deleteRefreshToken(email);
+
+    return new MemberLogoutResponse(email, result);
   }
 
 

--- a/src/main/java/com/blog/som/domain/member/security/service/AuthService.java
+++ b/src/main/java/com/blog/som/domain/member/security/service/AuthService.java
@@ -49,6 +49,10 @@ public class AuthService implements UserDetailsService {
     return MemberDto.fromEntity(member);
   }
 
+  public void saveRefreshToken(String email, String refreshToken){
+    tokenRepository.saveRefreshToken(email, refreshToken);
+  }
+
   public MemberLogoutResponse logoutMember(String email, String accessToken){
     //accessToken blacklist 추가
     tokenRepository.addBlacklistAccessToken(accessToken, email);

--- a/src/main/java/com/blog/som/domain/member/security/token/TokenConstant.java
+++ b/src/main/java/com/blog/som/domain/member/security/token/TokenConstant.java
@@ -12,5 +12,9 @@ public class TokenConstant {
 
   public static final long REFRESH_TOKEN_EXPIRE_TIME = (long) 1000 * 60 * 60 * 24 * 30;// 한 달
 
+  public static final String ACCESS_TOKEN_BLACKLIST_PREFIX = "AT-";
+
+  public static final String REFRESH_TOKEN_EMAIL_KEY_PREFIX = "RT-";
+
 
 }

--- a/src/main/java/com/blog/som/domain/member/security/token/TokenConstant.java
+++ b/src/main/java/com/blog/som/domain/member/security/token/TokenConstant.java
@@ -12,6 +12,8 @@ public class TokenConstant {
 
   public static final long REFRESH_TOKEN_EXPIRE_TIME = (long) 1000 * 60 * 60 * 24 * 30;// 한 달
 
+  public static final String REFRESH_TOKEN_PREFIX = "RT-";
+
   public static final String ACCESS_TOKEN_BLACKLIST_PREFIX = "AT-";
 
   public static final String REFRESH_TOKEN_EMAIL_KEY_PREFIX = "RT-";

--- a/src/main/java/com/blog/som/global/redis/token/RedisTokenRepository.java
+++ b/src/main/java/com/blog/som/global/redis/token/RedisTokenRepository.java
@@ -1,0 +1,32 @@
+package com.blog.som.global.redis.token;
+
+import com.blog.som.domain.member.security.token.TokenConstant;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Repository;
+
+@Slf4j
+@RequiredArgsConstructor
+@Repository
+public class RedisTokenRepository implements TokenRepository {
+
+  private final RedisTemplate redisTemplate;
+
+  @Override
+  public void addBlacklistAccessToken(String accessToken, String email) {
+    ValueOperations<String, String> values = redisTemplate.opsForValue();
+    values.set(
+        TokenConstant.ACCESS_TOKEN_BLACKLIST_PREFIX + accessToken,
+        email,
+        Duration.ofMillis(TokenConstant.ACCESS_TOKEN_EXPIRE_TIME)
+    );
+  }
+
+  @Override
+  public boolean deleteRefreshToken(String email) {
+    return redisTemplate.delete(TokenConstant.REFRESH_TOKEN_EMAIL_KEY_PREFIX + email);
+  }
+}

--- a/src/main/java/com/blog/som/global/redis/token/RedisTokenRepository.java
+++ b/src/main/java/com/blog/som/global/redis/token/RedisTokenRepository.java
@@ -13,7 +13,17 @@ import org.springframework.stereotype.Repository;
 @Repository
 public class RedisTokenRepository implements TokenRepository {
 
-  private final RedisTemplate redisTemplate;
+  private final RedisTemplate<String, String> redisTemplate;
+
+  @Override
+  public void saveRefreshToken(String email, String refreshToken) {
+    ValueOperations<String, String> values = redisTemplate.opsForValue();
+    values.set(
+        TokenConstant.REFRESH_TOKEN_PREFIX + email,
+        refreshToken,
+        Duration.ofMillis(TokenConstant.REFRESH_TOKEN_EXPIRE_TIME)
+    );
+  }
 
   @Override
   public void addBlacklistAccessToken(String accessToken, String email) {
@@ -27,6 +37,6 @@ public class RedisTokenRepository implements TokenRepository {
 
   @Override
   public boolean deleteRefreshToken(String email) {
-    return redisTemplate.delete(TokenConstant.REFRESH_TOKEN_EMAIL_KEY_PREFIX + email);
+    return Boolean.TRUE.equals(redisTemplate.delete(TokenConstant.REFRESH_TOKEN_EMAIL_KEY_PREFIX + email));
   }
 }

--- a/src/main/java/com/blog/som/global/redis/token/TokenRepository.java
+++ b/src/main/java/com/blog/som/global/redis/token/TokenRepository.java
@@ -1,0 +1,8 @@
+package com.blog.som.global.redis.token;
+
+public interface TokenRepository {
+
+  void addBlacklistAccessToken(String accessToken, String email);
+
+  boolean deleteRefreshToken(String email);
+}

--- a/src/main/java/com/blog/som/global/redis/token/TokenRepository.java
+++ b/src/main/java/com/blog/som/global/redis/token/TokenRepository.java
@@ -2,6 +2,8 @@ package com.blog.som.global.redis.token;
 
 public interface TokenRepository {
 
+  void saveRefreshToken(String email, String refreshToken);
+
   void addBlacklistAccessToken(String accessToken, String email);
 
   boolean deleteRefreshToken(String email);


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요.  -->
### [로그아웃]
- accessToken blacklist 추가 -> Redis에 `key=AT-{accessToken}`으로 저장
- 기존에 존재하던 refreshToken 삭제 -> Redis에서 delete `key=RT-{email}`

### [로그인 시 RT 저장]
- Redis에 `key=RT-{email}`, `value={refreshToken}` 저장

---

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 

