### PR TITLE
토큰 재발급 (reissue) API

### DIFF
--- a/src/main/java/com/blog/som/domain/member/controller/AuthController.java
+++ b/src/main/java/com/blog/som/domain/member/controller/AuthController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
-@Api(tags = "인증(Login, Logout, Token 등)")
+@Api(tags = "인증 관련 (login, logout)")
 @RequiredArgsConstructor
 @RestController
 public class AuthController {

--- a/src/main/java/com/blog/som/domain/member/controller/AuthController.java
+++ b/src/main/java/com/blog/som/domain/member/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.blog.som.domain.member.controller;
 
 import com.blog.som.domain.member.dto.MemberDto;
 import com.blog.som.domain.member.dto.MemberLogin;
+import com.blog.som.domain.member.dto.MemberLogin.Response;
 import com.blog.som.domain.member.dto.MemberLogoutResponse;
 import com.blog.som.domain.member.dto.TokenResponse;
 import com.blog.som.domain.member.security.service.AuthService;
@@ -17,7 +18,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
-@Api(tags = "인증 관련 (login, logout)")
+@Api(tags = "인증 관련 (login, logout, token)")
 @RequiredArgsConstructor
 @RestController
 public class AuthController {
@@ -48,6 +49,18 @@ public class AuthController {
         authService.logoutMember(loginMember.getEmail(), jwtTokenService.resolveTokenFromRequest(bearerToken));
 
     return ResponseEntity.ok(memberLogoutResponse);
+  }
+
+  @ApiOperation(value = "토큰 재발급", notes = "[RefreshToken] header에 Bearer {refreshToken}을 받으면 AT와 RT를 모두 재발급")
+  @PostMapping("/reissue")
+  public ResponseEntity<MemberLogin.Response> reissueToken(
+      @AuthenticationPrincipal LoginMember loginMember,
+      @RequestHeader("RefreshToken") String refreshToken
+      ){
+    TokenResponse tokenResponse = jwtTokenService.generateTokenResponse(loginMember.getEmail(), loginMember.getRole());
+    MemberDto memberDto = authService.saveRefreshToken(loginMember.getEmail(), tokenResponse.getRefreshToken());
+
+    return ResponseEntity.ok(new Response(tokenResponse, memberDto));
   }
 
 }

--- a/src/main/java/com/blog/som/domain/member/controller/AuthController.java
+++ b/src/main/java/com/blog/som/domain/member/controller/AuthController.java
@@ -57,6 +57,9 @@ public class AuthController {
       @AuthenticationPrincipal LoginMember loginMember,
       @RequestHeader("RefreshToken") String refreshToken
       ){
+
+    //refreshToken이 일치하는지 확인
+    authService.checkRefreshToken(loginMember.getEmail(), jwtTokenService.resolveTokenFromRequest(refreshToken));
     TokenResponse tokenResponse = jwtTokenService.generateTokenResponse(loginMember.getEmail(), loginMember.getRole());
     MemberDto memberDto = authService.saveRefreshToken(loginMember.getEmail(), tokenResponse.getRefreshToken());
 

--- a/src/main/java/com/blog/som/domain/member/security/config/SecurityConfig.java
+++ b/src/main/java/com/blog/som/domain/member/security/config/SecurityConfig.java
@@ -80,7 +80,7 @@ public class SecurityConfig {
 
   @Bean
   public WebSecurityCustomizer webSecurityCustomizer() {
-    return web -> web.ignoring().antMatchers("/login", "/logout", "/exception/**");
+    return web -> web.ignoring().antMatchers("/login", "/logout", "/reissue", "/exception/**");
   }
 
   @Bean

--- a/src/main/java/com/blog/som/domain/member/security/service/AuthService.java
+++ b/src/main/java/com/blog/som/domain/member/security/service/AuthService.java
@@ -49,8 +49,11 @@ public class AuthService implements UserDetailsService {
     return MemberDto.fromEntity(member);
   }
 
-  public void saveRefreshToken(String email, String refreshToken){
+  public MemberDto saveRefreshToken(String email, String refreshToken){
+    MemberEntity member = memberRepository.findByEmail(email)
+        .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
     tokenRepository.saveRefreshToken(email, refreshToken);
+    return MemberDto.fromEntity(member);
   }
 
   public MemberLogoutResponse logoutMember(String email, String accessToken){
@@ -61,6 +64,7 @@ public class AuthService implements UserDetailsService {
 
     return new MemberLogoutResponse(email, result);
   }
+
 
 
   @Override

--- a/src/main/java/com/blog/som/domain/member/security/service/AuthService.java
+++ b/src/main/java/com/blog/som/domain/member/security/service/AuthService.java
@@ -65,7 +65,9 @@ public class AuthService implements UserDetailsService {
     return new MemberLogoutResponse(email, result);
   }
 
-
+  public boolean checkRefreshToken(String email, String refreshToken){
+    return tokenRepository.checkRefreshToken(email, refreshToken);
+  }
 
   @Override
   public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {

--- a/src/main/java/com/blog/som/global/exception/ErrorCode.java
+++ b/src/main/java/com/blog/som/global/exception/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
   JWT_TOKEN_WRONG_TYPE(HttpStatus.FORBIDDEN, "JWT 토큰 형식에 문제가 있습니다."),
   JWT_TOKEN_MALFORMED(HttpStatus.FORBIDDEN, "JWT 토큰이 변조되었습니다."),
   NO_JWT_TOKEN(HttpStatus.FORBIDDEN, "JWT 토큰이 존재하지 않습니다."),
+  REFRESH_TOKEN_NOT_COINCIDENCE(HttpStatus.FORBIDDEN, "RefreshToken이 일치하지 않습니다."),
 
 
   //global

--- a/src/main/java/com/blog/som/global/redis/token/RedisTokenRepository.java
+++ b/src/main/java/com/blog/som/global/redis/token/RedisTokenRepository.java
@@ -1,12 +1,15 @@
 package com.blog.som.global.redis.token;
 
 import com.blog.som.domain.member.security.token.TokenConstant;
+import com.blog.som.global.exception.ErrorCode;
+import com.blog.som.global.exception.custom.CustomSecurityException;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -38,5 +41,21 @@ public class RedisTokenRepository implements TokenRepository {
   @Override
   public boolean deleteRefreshToken(String email) {
     return Boolean.TRUE.equals(redisTemplate.delete(TokenConstant.REFRESH_TOKEN_EMAIL_KEY_PREFIX + email));
+  }
+
+  @Override
+  public boolean checkRefreshToken(String email, String refreshToken) {
+    ValueOperations<String, String> values = redisTemplate.opsForValue();
+    redisTemplate.hasKey(TokenConstant.REFRESH_TOKEN_EMAIL_KEY_PREFIX + email);
+    String rt = values.get(TokenConstant.REFRESH_TOKEN_EMAIL_KEY_PREFIX + email);
+    //RT가 존재하지 않을 때
+    if(!StringUtils.hasText(rt)){
+      return false;
+    }
+    //해당 유저의 RT가 정확할 때
+    if(refreshToken.equals(rt)){
+      return true;
+    }
+    throw new CustomSecurityException(ErrorCode.REFRESH_TOKEN_NOT_COINCIDENCE);
   }
 }

--- a/src/main/java/com/blog/som/global/redis/token/TokenRepository.java
+++ b/src/main/java/com/blog/som/global/redis/token/TokenRepository.java
@@ -7,4 +7,7 @@ public interface TokenRepository {
   void addBlacklistAccessToken(String accessToken, String email);
 
   boolean deleteRefreshToken(String email);
+
+  boolean checkRefreshToken(String email, String refreshToken);
+
 }

--- a/src/test/java/com/blog/som/domain/member/security/service/AuthServiceTest.java
+++ b/src/test/java/com/blog/som/domain/member/security/service/AuthServiceTest.java
@@ -139,6 +139,46 @@ class AuthServiceTest {
     }
   }
 
+  @Nested
+  @DisplayName("RefreshToken 저장")
+  class SaveRefreshToken{
+
+    @Test
+    @DisplayName("성공")
+    void saveRefreshToken(){
+      MemberEntity member = EntityCreator.createMember(1L);
+      String refreshToken = "test.refreshToken";
+      //given
+      when(memberRepository.findByEmail(member.getEmail()))
+          .thenReturn(Optional.of(member));
+
+      //when
+      MemberDto result = authService.saveRefreshToken(member.getEmail(), refreshToken);
+
+      //then
+      verify(tokenRepository, times(1)).saveRefreshToken(member.getEmail(), refreshToken);
+      assertThat(result.getMemberId()).isEqualTo(member.getMemberId());
+      assertThat(result.getEmail()).isEqualTo(member.getEmail());
+
+    }
+
+    @Test
+    @DisplayName("실패 : MEMBER_NOT_FOUND")
+    void saveRefreshToken_MEMBER_NOT_FOUND(){
+      MemberEntity member = EntityCreator.createMember(1L);
+      String refreshToken = "test.refreshToken";
+      //given
+      when(memberRepository.findByEmail(member.getEmail()))
+          .thenReturn(Optional.empty());
+
+      //when
+      //then
+      MemberException memberException =
+          assertThrows(MemberException.class, () -> authService.saveRefreshToken(member.getEmail(), refreshToken));
+      assertThat(memberException.getErrorCode()).isEqualTo(ErrorCode.MEMBER_NOT_FOUND);
+    }
+  }
+
   @Test
   @DisplayName("로그아웃")
   void logoutMember(){


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요.  -->
### [토큰 재발급 API]
- `RefreshToken` Request Header에 {refreshToken}을 담아서 `POST /reissue` 요청한다.
- 재발급 요청 시 accessToken과 refreshToken을 모두 재발급 한다.
- Redis에 `key=RT-{email}`, `value=새로운 {refreshToken}`을 저장(덮어쓰기) 한다.

---

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 

