### PR TITLE
Refactor : AuthController 로그인, 로그아웃, reissue 리팩터링

### DIFF
--- a/src/main/java/com/blog/som/domain/member/controller/AuthController.java
+++ b/src/main/java/com/blog/som/domain/member/controller/AuthController.java
@@ -1,10 +1,8 @@
 package com.blog.som.domain.member.controller;
 
-import com.blog.som.domain.member.dto.MemberDto;
 import com.blog.som.domain.member.dto.MemberLogin;
 import com.blog.som.domain.member.dto.MemberLogin.Response;
 import com.blog.som.domain.member.dto.MemberLogoutResponse;
-import com.blog.som.domain.member.dto.TokenResponse;
 import com.blog.som.domain.member.security.service.AuthService;
 import com.blog.som.domain.member.security.token.JwtTokenService;
 import com.blog.som.domain.member.security.userdetails.LoginMember;
@@ -53,13 +51,8 @@ public class AuthController {
       @AuthenticationPrincipal LoginMember loginMember,
       @RequestHeader("RefreshToken") String refreshToken
       ){
-
-    //refreshToken이 일치하는지 확인
-    authService.checkRefreshToken(loginMember.getEmail(), jwtTokenService.resolveTokenFromRequest(refreshToken));
-    TokenResponse tokenResponse = jwtTokenService.generateTokenResponse(loginMember.getEmail(), loginMember.getRole());
-    MemberDto memberDto = authService.saveRefreshToken(loginMember.getEmail(), tokenResponse.getRefreshToken());
-
-    return ResponseEntity.ok(new Response(tokenResponse, memberDto));
+    Response response = authService.reissueTokens(loginMember.getEmail(), loginMember.getRole(), refreshToken);
+    return ResponseEntity.ok(response);
   }
 
 }

--- a/src/main/java/com/blog/som/domain/member/controller/AuthController.java
+++ b/src/main/java/com/blog/som/domain/member/controller/AuthController.java
@@ -30,13 +30,9 @@ public class AuthController {
   @PostMapping("/login")
   public ResponseEntity<MemberLogin.Response> login(@RequestBody MemberLogin.Request request) {
 
-    MemberDto member = authService.loginMember(request);
+    Response response = authService.loginMember(request);
 
-    TokenResponse tokenResponse = jwtTokenService.generateTokenResponse(member.getEmail(), member.getRole());
-
-    authService.saveRefreshToken(member.getEmail(), tokenResponse.getRefreshToken());
-
-    return ResponseEntity.ok(new MemberLogin.Response(tokenResponse, member));
+    return ResponseEntity.ok(response);
   }
 
   @ApiOperation(value = "로그아웃", notes = "accessToken blacklist 처리")

--- a/src/main/java/com/blog/som/domain/member/security/service/AuthService.java
+++ b/src/main/java/com/blog/som/domain/member/security/service/AuthService.java
@@ -1,13 +1,11 @@
 package com.blog.som.domain.member.security.service;
 
 
-
 import com.blog.som.domain.member.dto.MemberDto;
 import com.blog.som.domain.member.dto.MemberLogin;
 import com.blog.som.domain.member.dto.MemberLogoutResponse;
 import com.blog.som.domain.member.entity.MemberEntity;
 import com.blog.som.domain.member.repository.MemberRepository;
-import com.blog.som.domain.member.security.userdetails.LoginMember;
 import com.blog.som.domain.member.type.Role;
 import com.blog.som.global.components.mail.MailSender;
 import com.blog.som.global.components.mail.SendMailDto;
@@ -17,15 +15,12 @@ import com.blog.som.global.exception.custom.MemberException;
 import com.blog.som.global.redis.token.TokenRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 @Slf4j
 @RequiredArgsConstructor
 @Service
-public class AuthService implements UserDetailsService {
+public class AuthService{
 
   private final MemberRepository memberRepository;
   private final MailSender mailSender;
@@ -69,12 +64,4 @@ public class AuthService implements UserDetailsService {
     return tokenRepository.checkRefreshToken(email, refreshToken);
   }
 
-  @Override
-  public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-    MemberEntity member = memberRepository.findByEmail(username)
-        .orElseThrow(() -> new UsernameNotFoundException(ErrorCode.MEMBER_NOT_FOUND.getDescription()));
-    log.info("인증 성공[ ID : {} ]", member.getEmail());
-
-    return new LoginMember(member);
-  }
 }

--- a/src/main/java/com/blog/som/domain/member/security/service/CustomUserDetailsService.java
+++ b/src/main/java/com/blog/som/domain/member/security/service/CustomUserDetailsService.java
@@ -1,0 +1,29 @@
+package com.blog.som.domain.member.security.service;
+
+import com.blog.som.domain.member.entity.MemberEntity;
+import com.blog.som.domain.member.repository.MemberRepository;
+import com.blog.som.domain.member.security.userdetails.LoginMember;
+import com.blog.som.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+  private final MemberRepository memberRepository;
+
+  @Override
+  public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+    MemberEntity member = memberRepository.findByEmail(username)
+        .orElseThrow(() -> new UsernameNotFoundException(ErrorCode.MEMBER_NOT_FOUND.getDescription()));
+    log.info("인증 성공[ ID : {} ]", member.getEmail());
+
+    return new LoginMember(member);
+  }
+}

--- a/src/main/java/com/blog/som/domain/member/security/token/JwtTokenService.java
+++ b/src/main/java/com/blog/som/domain/member/security/token/JwtTokenService.java
@@ -6,7 +6,7 @@ import static com.blog.som.domain.member.security.token.TokenConstant.KEY_ROLES;
 import static com.blog.som.domain.member.security.token.TokenConstant.REFRESH_TOKEN_EXPIRE_TIME;
 
 import com.blog.som.domain.member.dto.TokenResponse;
-import com.blog.som.domain.member.security.service.AuthService;
+import com.blog.som.domain.member.security.service.CustomUserDetailsService;
 import com.blog.som.domain.member.type.Role;
 import com.blog.som.global.exception.ErrorCode;
 import io.jsonwebtoken.Claims;
@@ -33,7 +33,7 @@ import org.springframework.util.StringUtils;
 @RequiredArgsConstructor
 public class JwtTokenService {
 
-  private final AuthService authService;
+  private final CustomUserDetailsService userDetailsService;
 
   @Value("${spring.jwt.secret}")
   private String secretKey;
@@ -84,7 +84,7 @@ public class JwtTokenService {
 
   public Authentication getAuthentication(String token) {
     String username = this.parseClaims(token).getSubject();
-    UserDetails userDetails = authService.loadUserByUsername(username);
+    UserDetails userDetails = userDetailsService.loadUserByUsername(username);
     return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
   }
 

--- a/src/test/java/com/blog/som/domain/member/security/service/AuthServiceTest.java
+++ b/src/test/java/com/blog/som/domain/member/security/service/AuthServiceTest.java
@@ -194,7 +194,7 @@ class AuthServiceTest {
     //then
     verify(tokenRepository,times(1)).addBlacklistAccessToken(accessToken, email);
     assertThat(response.getEmail()).isEqualTo(email);
-    assertThat(response.isLogoutResult()).isEqualTo(true);
+    assertThat(response.isLogoutResult()).isTrue();
 
 
   }

--- a/src/test/java/com/blog/som/domain/member/security/service/AuthServiceTest.java
+++ b/src/test/java/com/blog/som/domain/member/security/service/AuthServiceTest.java
@@ -151,45 +151,6 @@ class AuthServiceTest {
     }
   }
 
-  @Nested
-  @DisplayName("RefreshToken 저장")
-  class SaveRefreshToken{
-
-    @Test
-    @DisplayName("성공")
-    void saveRefreshToken(){
-      MemberEntity member = EntityCreator.createMember(1L);
-      String refreshToken = "test.refreshToken";
-      //given
-      when(memberRepository.findByEmail(member.getEmail()))
-          .thenReturn(Optional.of(member));
-
-      //when
-      MemberDto result = authService.saveRefreshToken(member.getEmail(), refreshToken);
-
-      //then
-      verify(tokenRepository, times(1)).saveRefreshToken(member.getEmail(), refreshToken);
-      assertThat(result.getMemberId()).isEqualTo(member.getMemberId());
-      assertThat(result.getEmail()).isEqualTo(member.getEmail());
-
-    }
-
-    @Test
-    @DisplayName("실패 : MEMBER_NOT_FOUND")
-    void saveRefreshToken_MEMBER_NOT_FOUND(){
-      MemberEntity member = EntityCreator.createMember(1L);
-      String refreshToken = "test.refreshToken";
-      //given
-      when(memberRepository.findByEmail(member.getEmail()))
-          .thenReturn(Optional.empty());
-
-      //when
-      //then
-      MemberException memberException =
-          assertThrows(MemberException.class, () -> authService.saveRefreshToken(member.getEmail(), refreshToken));
-      assertThat(memberException.getErrorCode()).isEqualTo(ErrorCode.MEMBER_NOT_FOUND);
-    }
-  }
 
   @Test
   @DisplayName("로그아웃")

--- a/src/test/java/com/blog/som/domain/member/security/service/AuthServiceTest.java
+++ b/src/test/java/com/blog/som/domain/member/security/service/AuthServiceTest.java
@@ -199,43 +199,4 @@ class AuthServiceTest {
 
   }
 
-
-  @Nested
-  @DisplayName("loadUserByUsername")
-  class LoadUserByUsername{
-    @Test
-    @DisplayName("성공")
-    void loadUserByUsername(){
-      MemberEntity member = EntityCreator.createMember(1L);
-      String username = member.getEmail();
-      //given
-      when(memberRepository.findByEmail(username))
-          .thenReturn(Optional.of(member));
-
-      //when
-      UserDetails userDetails = authService.loadUserByUsername(username);
-
-      //then
-      assertThat(userDetails.getUsername()).isEqualTo(username);
-      assertThat(userDetails.getPassword()).isEqualTo(member.getPassword());
-
-
-    }
-
-    @Test
-    @DisplayName("실패 : UsernameNotFoundException")
-    void loadUserByUsername_UsernameNotFoundException(){
-      MemberEntity member = EntityCreator.createMember(1L);
-      String username = member.getEmail();
-      //given
-      when(memberRepository.findByEmail(username))
-          .thenReturn(Optional.empty());
-
-      //when
-      //then
-      UsernameNotFoundException usernameNotFoundException =
-          assertThrows(UsernameNotFoundException.class, () -> authService.loadUserByUsername(username));
-      assertThat(usernameNotFoundException.getMessage()).isEqualTo(ErrorCode.MEMBER_NOT_FOUND.getDescription());
-    }
-  }
 }

--- a/src/test/java/com/blog/som/domain/member/security/service/CustomUserDetailsServiceTest.java
+++ b/src/test/java/com/blog/som/domain/member/security/service/CustomUserDetailsServiceTest.java
@@ -1,0 +1,71 @@
+package com.blog.som.domain.member.security.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+import com.blog.som.EntityCreator;
+import com.blog.som.domain.member.entity.MemberEntity;
+import com.blog.som.domain.member.repository.MemberRepository;
+import com.blog.som.global.exception.ErrorCode;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+@Slf4j
+@ExtendWith(MockitoExtension.class)
+class CustomUserDetailsServiceTest {
+
+  @Mock
+  private MemberRepository memberRepository;
+
+  @InjectMocks
+  private CustomUserDetailsService userDetailsService;
+
+  @Nested
+  @DisplayName("loadUserByUsername")
+  class LoadUserByUsername{
+    @Test
+    @DisplayName("성공")
+    void loadUserByUsername(){
+      MemberEntity member = EntityCreator.createMember(1L);
+      String username = member.getEmail();
+      //given
+      when(memberRepository.findByEmail(username))
+          .thenReturn(Optional.of(member));
+
+      //when
+      UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+
+      //then
+      assertThat(userDetails.getUsername()).isEqualTo(username);
+      assertThat(userDetails.getPassword()).isEqualTo(member.getPassword());
+
+
+    }
+
+    @Test
+    @DisplayName("실패 : UsernameNotFoundException")
+    void loadUserByUsername_UsernameNotFoundException(){
+      MemberEntity member = EntityCreator.createMember(1L);
+      String username = member.getEmail();
+      //given
+      when(memberRepository.findByEmail(username))
+          .thenReturn(Optional.empty());
+
+      //when
+      //then
+      UsernameNotFoundException usernameNotFoundException =
+          assertThrows(UsernameNotFoundException.class, () -> userDetailsService.loadUserByUsername(username));
+      assertThat(usernameNotFoundException.getMessage()).isEqualTo(ErrorCode.MEMBER_NOT_FOUND.getDescription());
+    }
+  }
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요.  -->
### [UserDetailsService 분리]
- `JwtTokenService`에서 `loadUserByUsername` 메서드를 이용하기 위해 `AuthService`를 주입받아 사용해서, 
AuthService에서 JwtTokenService를 주입받을 수 없었음 (순환 참조 발생)
- controller에 여러 의존성을 두고 처리하던 것을 리팩터링 
- AuthService에서 UserDetailsService를 implement 하던 것을 분리하여 `CustomUserDetailsService`를 만들어서 해결하였음

### [Login, Reissue 로직 수정]
- 위의 변경 사항에 따라 Controller에서 여러 서비스를 호출하던 것 수정
- `Login`, `Reissue` 시 각각 AuthService의 메서드에서 모두 로직을 처리하고, 
`AuthController`는 `AuthService`에만 의존하도록 수정

---

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 

