### PR TITLE
Feat : 회원 정보 수정, 비밀번호 수정 API

### DIFF
--- a/src/main/java/com/blog/som/TestController.java
+++ b/src/main/java/com/blog/som/TestController.java
@@ -1,0 +1,25 @@
+package com.blog.som;
+
+import com.blog.som.domain.member.security.userdetails.LoginMember;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Api(tags = "test용 컨트롤러 - security 오픈되어있음")
+@RequiredArgsConstructor
+@RequestMapping("/test")
+public class TestController {
+  
+  @ApiOperation(value = "로그인 멤버 확인", notes = "토큰만 Header에 포함시켜서 로그인 멤버 확인")
+  @GetMapping("/loginUser")
+  public ResponseEntity<?> loginUser(@AuthenticationPrincipal LoginMember loginMember){
+      
+      return ResponseEntity.ok(loginMember);
+  }
+  
+  
+}

--- a/src/main/java/com/blog/som/domain/member/controller/AuthController.java
+++ b/src/main/java/com/blog/som/domain/member/controller/AuthController.java
@@ -11,6 +11,7 @@ import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -46,7 +47,7 @@ public class AuthController {
   }
 
   @ApiOperation(value = "토큰 재발급", notes = "[RefreshToken] header에 Bearer {refreshToken}을 받으면 AT와 RT를 모두 재발급")
-  @PostMapping("/reissue")
+  @GetMapping("/reissue")
   public ResponseEntity<MemberLogin.Response> reissueToken(
       @AuthenticationPrincipal LoginMember loginMember,
       @RequestHeader("RefreshToken") String refreshToken

--- a/src/main/java/com/blog/som/domain/member/controller/MemberController.java
+++ b/src/main/java/com/blog/som/domain/member/controller/MemberController.java
@@ -1,16 +1,19 @@
 package com.blog.som.domain.member.controller;
 
 import com.blog.som.domain.member.dto.EmailAuthResult;
+import com.blog.som.domain.member.dto.MemberDto;
+import com.blog.som.domain.member.dto.MemberEditRequest;
 import com.blog.som.domain.member.dto.MemberRegister;
 import com.blog.som.domain.member.dto.MemberRegister.Response;
+import com.blog.som.domain.member.security.userdetails.LoginMember;
 import com.blog.som.domain.member.service.MemberService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -39,26 +42,29 @@ public class MemberController {
   }
 
   @ApiOperation(value = "회원 정보 수정", notes = "(TODO)비밀번호 제외")
-  @PutMapping("/member/{memberId}")
-  public ResponseEntity<?> editMemberInfo(@PathVariable Long memberId){
-    return ResponseEntity.ok(null);
+  @PutMapping("/member")
+  public ResponseEntity<MemberDto> editMemberInfo(
+      @RequestBody MemberEditRequest request,
+      @AuthenticationPrincipal LoginMember loginMember){
+    MemberDto result = memberService.editMemberInfo(loginMember.getMemberId(), request);
+    return ResponseEntity.ok(result);
   }
 
   @ApiOperation(value = "회원 비밀번호 수정", notes = "(TODO)")
-  @PutMapping("/member/{memberId}/edit-password")
-  public ResponseEntity<?> editMemberPassword(@PathVariable Long memberId){
+  @PutMapping("/member/edit-password")
+  public ResponseEntity<?> editMemberPassword(){
     return ResponseEntity.ok(null);
   }
 
   @ApiOperation(value = "프로필 사진 변경(등록)", notes = "(TODO)기존의 것이 있으면 덮어쓰기")
-  @PutMapping("/member/{memberId}/profile-image")
-  public ResponseEntity<?> editProfileImage(@PathVariable Long memberId){
+  @PutMapping("/member/profile-image")
+  public ResponseEntity<?> editProfileImage(){
     return ResponseEntity.ok(null);
   }
 
   @ApiOperation(value = "프로필 사진 삭제", notes = "(TODO)프로필 사진을 null로 수정")
-  @DeleteMapping("/member/{memberId}/profile-image/remove")
-  public ResponseEntity<?> deleteProfileImage(@PathVariable Long memberId){
+  @DeleteMapping("/member/profile-image/remove")
+  public ResponseEntity<?> deleteProfileImage(){
     return ResponseEntity.ok(null);
   }
 

--- a/src/main/java/com/blog/som/domain/member/controller/MemberController.java
+++ b/src/main/java/com/blog/som/domain/member/controller/MemberController.java
@@ -8,8 +8,11 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,7 +25,7 @@ public class MemberController {
   private final MemberService memberService;
 
   @ApiOperation("회원 가입")
-  @PostMapping("/member/register")
+  @PostMapping("/register")
   public ResponseEntity<MemberRegister.Response> registerMember(@RequestBody MemberRegister.Request request) {
     Response response = memberService.registerMember(request);
     return ResponseEntity.ok(response);
@@ -33,6 +36,30 @@ public class MemberController {
   public ResponseEntity<EmailAuthResult> emailAuth(@RequestParam String key){
     EmailAuthResult emailAuthResult = memberService.emailAuth(key);
     return ResponseEntity.ok(emailAuthResult);
+  }
+
+  @ApiOperation(value = "회원 정보 수정", notes = "(TODO)비밀번호 제외")
+  @PutMapping("/member/{memberId}")
+  public ResponseEntity<?> editMemberInfo(@PathVariable Long memberId){
+    return ResponseEntity.ok(null);
+  }
+
+  @ApiOperation(value = "회원 비밀번호 수정", notes = "(TODO)")
+  @PutMapping("/member/{memberId}/edit-password")
+  public ResponseEntity<?> editMemberPassword(@PathVariable Long memberId){
+    return ResponseEntity.ok(null);
+  }
+
+  @ApiOperation(value = "프로필 사진 변경(등록)", notes = "(TODO)기존의 것이 있으면 덮어쓰기")
+  @PutMapping("/member/{memberId}/profile-image")
+  public ResponseEntity<?> editProfileImage(@PathVariable Long memberId){
+    return ResponseEntity.ok(null);
+  }
+
+  @ApiOperation(value = "프로필 사진 삭제", notes = "(TODO)프로필 사진을 null로 수정")
+  @DeleteMapping("/member/{memberId}/profile-image/remove")
+  public ResponseEntity<?> deleteProfileImage(@PathVariable Long memberId){
+    return ResponseEntity.ok(null);
   }
 
 

--- a/src/main/java/com/blog/som/domain/member/controller/MemberController.java
+++ b/src/main/java/com/blog/som/domain/member/controller/MemberController.java
@@ -3,6 +3,7 @@ package com.blog.som.domain.member.controller;
 import com.blog.som.domain.member.dto.EmailAuthResult;
 import com.blog.som.domain.member.dto.MemberDto;
 import com.blog.som.domain.member.dto.MemberEditRequest;
+import com.blog.som.domain.member.dto.MemberPasswordEdit;
 import com.blog.som.domain.member.dto.MemberRegister;
 import com.blog.som.domain.member.dto.MemberRegister.Response;
 import com.blog.som.domain.member.security.userdetails.LoginMember;
@@ -10,6 +11,7 @@ import com.blog.som.domain.member.service.MemberService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -20,6 +22,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @Api(tags = "회원(Member)")
 @RequiredArgsConstructor
 @RestController
@@ -30,6 +33,7 @@ public class MemberController {
   @ApiOperation("회원 가입")
   @PostMapping("/register")
   public ResponseEntity<MemberRegister.Response> registerMember(@RequestBody MemberRegister.Request request) {
+
     Response response = memberService.registerMember(request);
     return ResponseEntity.ok(response);
   }
@@ -37,34 +41,42 @@ public class MemberController {
   @ApiOperation("이메일 인증")
   @GetMapping("/auth/email-auth")
   public ResponseEntity<EmailAuthResult> emailAuth(@RequestParam String key){
+
     EmailAuthResult emailAuthResult = memberService.emailAuth(key);
     return ResponseEntity.ok(emailAuthResult);
   }
 
-  @ApiOperation(value = "회원 정보 수정", notes = "(TODO)비밀번호 제외")
+  @ApiOperation(value = "회원 정보 수정", notes = "비밀번호 제외")
   @PutMapping("/member")
   public ResponseEntity<MemberDto> editMemberInfo(
       @RequestBody MemberEditRequest request,
       @AuthenticationPrincipal LoginMember loginMember){
+
     MemberDto result = memberService.editMemberInfo(loginMember.getMemberId(), request);
     return ResponseEntity.ok(result);
   }
 
-  @ApiOperation(value = "회원 비밀번호 수정", notes = "(TODO)")
+  @ApiOperation(value = "회원 비밀번호 수정")
   @PutMapping("/member/edit-password")
-  public ResponseEntity<?> editMemberPassword(){
-    return ResponseEntity.ok(null);
+  public ResponseEntity<MemberPasswordEdit.Response> editMemberPassword(
+      @RequestBody MemberPasswordEdit.Request request,
+      @AuthenticationPrincipal LoginMember loginMember){
+    MemberPasswordEdit.Response response =
+        memberService.editMemberPassword(loginMember.getMemberId(), request);
+    return ResponseEntity.ok(response);
   }
 
   @ApiOperation(value = "프로필 사진 변경(등록)", notes = "(TODO)기존의 것이 있으면 덮어쓰기")
   @PutMapping("/member/profile-image")
   public ResponseEntity<?> editProfileImage(){
+
     return ResponseEntity.ok(null);
   }
 
   @ApiOperation(value = "프로필 사진 삭제", notes = "(TODO)프로필 사진을 null로 수정")
   @DeleteMapping("/member/profile-image/remove")
   public ResponseEntity<?> deleteProfileImage(){
+
     return ResponseEntity.ok(null);
   }
 

--- a/src/main/java/com/blog/som/domain/member/dto/MemberEditRequest.java
+++ b/src/main/java/com/blog/som/domain/member/dto/MemberEditRequest.java
@@ -1,0 +1,22 @@
+package com.blog.som.domain.member.dto;
+
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class MemberEditRequest {
+  private String nickname;
+
+  private String phoneNumber;
+
+  private LocalDate birthDate;
+
+}

--- a/src/main/java/com/blog/som/domain/member/dto/MemberPasswordEdit.java
+++ b/src/main/java/com/blog/som/domain/member/dto/MemberPasswordEdit.java
@@ -1,0 +1,28 @@
+package com.blog.som.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+public class MemberPasswordEdit {
+
+  @Getter
+  @Setter
+  @AllArgsConstructor
+  @NoArgsConstructor
+  @Builder
+  public static class Request{
+    private String currentPassword;
+    private String newPassword;
+    private String newPasswordCheck;
+  }
+
+  @Getter
+  @AllArgsConstructor
+  public static class Response{
+    private Long memberId;
+    private String message;
+  }
+}

--- a/src/main/java/com/blog/som/domain/member/entity/MemberEntity.java
+++ b/src/main/java/com/blog/som/domain/member/entity/MemberEntity.java
@@ -87,4 +87,13 @@ public class MemberEntity {
   public int hashCode() {
     return Objects.hash(memberId);
   }
+
+  @Override
+  public String toString() {
+    return "MemberEntity{" +
+        "memberId=" + memberId +
+        ", email='" + email + '\'' +
+        ", nickname='" + nickname + '\'' +
+        '}';
+  }
 }

--- a/src/main/java/com/blog/som/domain/member/entity/MemberEntity.java
+++ b/src/main/java/com/blog/som/domain/member/entity/MemberEntity.java
@@ -1,5 +1,6 @@
 package com.blog.som.domain.member.entity;
 
+import com.blog.som.domain.member.dto.MemberEditRequest;
 import com.blog.som.domain.member.type.Role;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -63,6 +64,12 @@ public class MemberEntity {
   @Enumerated(EnumType.STRING)
   @Column(name = "role")
   private Role role;
+
+  public void editMember(MemberEditRequest request){
+    this.nickname = request.getNickname();
+    this.birthDate = request.getBirthDate();
+    this.phoneNumber = request.getPhoneNumber();
+  }
 
   @Override
   public boolean equals(Object o) {

--- a/src/main/java/com/blog/som/domain/member/security/config/SecurityConfig.java
+++ b/src/main/java/com/blog/som/domain/member/security/config/SecurityConfig.java
@@ -39,8 +39,9 @@ public class SecurityConfig {
       "/swagger-ui.html",
       "/swagger-ui/**",
       "/webjars/**",
-      "/member/register",
-      "/auth/email-auth"
+      "/register",
+      "/auth/email-auth",
+      "/test/**"
   };
 
   //멤버에게만 접근 허용

--- a/src/main/java/com/blog/som/domain/member/security/service/CustomUserDetailsService.java
+++ b/src/main/java/com/blog/som/domain/member/security/service/CustomUserDetailsService.java
@@ -22,7 +22,7 @@ public class CustomUserDetailsService implements UserDetailsService {
   public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
     MemberEntity member = memberRepository.findByEmail(username)
         .orElseThrow(() -> new UsernameNotFoundException(ErrorCode.MEMBER_NOT_FOUND.getDescription()));
-    log.info("인증 성공[ ID : {} ]", member.getEmail());
+    log.info("인증 성공[ ID: {}, EMAIL: {} ]", member.getMemberId(), member.getEmail());
 
     return new LoginMember(member);
   }

--- a/src/main/java/com/blog/som/domain/member/service/MemberService.java
+++ b/src/main/java/com/blog/som/domain/member/service/MemberService.java
@@ -3,6 +3,7 @@ package com.blog.som.domain.member.service;
 import com.blog.som.domain.member.dto.EmailAuthResult;
 import com.blog.som.domain.member.dto.MemberDto;
 import com.blog.som.domain.member.dto.MemberEditRequest;
+import com.blog.som.domain.member.dto.MemberPasswordEdit;
 import com.blog.som.domain.member.dto.MemberRegister;
 
 public interface MemberService {
@@ -12,4 +13,6 @@ public interface MemberService {
   EmailAuthResult emailAuth(String key);
 
   MemberDto editMemberInfo(Long memberId, MemberEditRequest request);
+
+  MemberPasswordEdit.Response editMemberPassword(Long memberId, MemberPasswordEdit.Request request);
 }

--- a/src/main/java/com/blog/som/domain/member/service/MemberService.java
+++ b/src/main/java/com/blog/som/domain/member/service/MemberService.java
@@ -1,6 +1,8 @@
 package com.blog.som.domain.member.service;
 
 import com.blog.som.domain.member.dto.EmailAuthResult;
+import com.blog.som.domain.member.dto.MemberDto;
+import com.blog.som.domain.member.dto.MemberEditRequest;
 import com.blog.som.domain.member.dto.MemberRegister;
 
 public interface MemberService {
@@ -8,4 +10,6 @@ public interface MemberService {
   MemberRegister.Response registerMember(MemberRegister.Request request);
 
   EmailAuthResult emailAuth(String key);
+
+  MemberDto editMemberInfo(Long memberId, MemberEditRequest request);
 }

--- a/src/main/java/com/blog/som/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/blog/som/domain/member/service/MemberServiceImpl.java
@@ -3,6 +3,7 @@ package com.blog.som.domain.member.service;
 import com.blog.som.domain.member.dto.EmailAuthResult;
 import com.blog.som.domain.member.dto.MemberDto;
 import com.blog.som.domain.member.dto.MemberEditRequest;
+import com.blog.som.domain.member.dto.MemberPasswordEdit;
 import com.blog.som.domain.member.dto.MemberRegister.Request;
 import com.blog.som.domain.member.dto.MemberRegister.Response;
 import com.blog.som.domain.member.entity.MemberEntity;
@@ -11,6 +12,7 @@ import com.blog.som.domain.member.type.Role;
 import com.blog.som.global.components.mail.MailSender;
 import com.blog.som.global.components.mail.SendMailDto;
 import com.blog.som.global.components.password.PasswordUtils;
+import com.blog.som.global.constant.ResponseConstant;
 import com.blog.som.global.exception.ErrorCode;
 import com.blog.som.global.exception.custom.MemberException;
 import com.blog.som.global.redis.email.EmailAuthRepository;
@@ -77,6 +79,23 @@ public class MemberServiceImpl implements MemberService {
     MemberEntity saved = memberRepository.save(member);
 
     return MemberDto.fromEntity(saved);
+  }
+
+  @Override
+  public MemberPasswordEdit.Response editMemberPassword(Long memberId, MemberPasswordEdit.Request request) {
+    MemberEntity member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+    if(!PasswordUtils.equalsPlainTextAndHashed(request.getCurrentPassword(), member.getPassword())){
+      throw new MemberException(ErrorCode.MEMBER_PASSWORD_INCORRECT);
+    }
+    if(!request.getNewPassword().equals(request.getNewPasswordCheck())){
+      throw new MemberException(ErrorCode.PASSWORD_CHECK_INCORRECT);
+    }
+
+    member.setPassword(PasswordUtils.encPassword(request.getNewPassword()));
+    memberRepository.save(member);
+
+    return new MemberPasswordEdit.Response(member.getMemberId(), ResponseConstant.PASSWORD_EDIT_COMPLETE);
   }
 
 }

--- a/src/main/java/com/blog/som/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/blog/som/domain/member/service/MemberServiceImpl.java
@@ -1,6 +1,8 @@
 package com.blog.som.domain.member.service;
 
 import com.blog.som.domain.member.dto.EmailAuthResult;
+import com.blog.som.domain.member.dto.MemberDto;
+import com.blog.som.domain.member.dto.MemberEditRequest;
 import com.blog.som.domain.member.dto.MemberRegister.Request;
 import com.blog.som.domain.member.dto.MemberRegister.Response;
 import com.blog.som.domain.member.entity.MemberEntity;
@@ -66,6 +68,15 @@ public class MemberServiceImpl implements MemberService {
     return new EmailAuthResult(true, member);
   }
 
+  @Override
+  public MemberDto editMemberInfo(Long memberId, MemberEditRequest request) {
+    MemberEntity member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+    member.editMember(request);
 
+    MemberEntity saved = memberRepository.save(member);
+
+    return MemberDto.fromEntity(saved);
+  }
 
 }

--- a/src/main/java/com/blog/som/global/constant/ResponseConstant.java
+++ b/src/main/java/com/blog/som/global/constant/ResponseConstant.java
@@ -6,5 +6,6 @@ public class ResponseConstant {
   public static final String MEMBER_REGISTER_COMPLETE = "회원 가입이 완료되었습니다. 이메일 인증을 완료해주세요.";
   public static final String EMAIL_AUTH_COMPLETE = "이메일 인증이 완료되었습니다.";
   public static final String EMAIL_AUTH_ALREADY_COMPLETED = "이미 이메일 인증이 완료된 회원입니다.";
+  public static final String PASSWORD_EDIT_COMPLETE = "비밀번호 변경이 완료되었습니다.";
 
 }

--- a/src/main/java/com/blog/som/global/exception/ErrorCode.java
+++ b/src/main/java/com/blog/som/global/exception/ErrorCode.java
@@ -10,16 +10,18 @@ public enum ErrorCode {
   //Member 관련
   MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다."),
   MEMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 회원가입 된 이메일입니다."),
-  EMAIL_AUTH_TIME_OUT(HttpStatus.NOT_FOUND, "이메일 인증 키가 만료되었거나, 잘못된 요청 입니다."),
-  EMAIL_AUTH_WRONG_KEY(HttpStatus.NOT_FOUND, "이메일 인증 키에 문제가 있습니다."),
-  EMAIL_AUTH_ALREADY_COMPLETE(HttpStatus.NOT_FOUND, "이미 이메일 인증 완료 된 회원입니다."),
-  EMAIL_AUTH_REQUIRED(HttpStatus.NOT_FOUND, "이메일 인증이 완료되지 않았습니다. 다시 이메일이 발송되었습니다."),
+  EMAIL_AUTH_TIME_OUT(HttpStatus.BAD_REQUEST, "이메일 인증 키가 만료되었거나, 잘못된 요청 입니다."),
+  EMAIL_AUTH_WRONG_KEY(HttpStatus.BAD_REQUEST, "이메일 인증 키에 문제가 있습니다."),
+  EMAIL_AUTH_ALREADY_COMPLETE(HttpStatus.BAD_REQUEST, "이미 이메일 인증 완료 된 회원입니다."),
+  EMAIL_AUTH_REQUIRED(HttpStatus.UNAUTHORIZED, "이메일 인증이 완료되지 않았습니다. 다시 이메일이 발송되었습니다."),
+  MEMBER_PASSWORD_INCORRECT(HttpStatus.BAD_REQUEST, "비밀번호가 틀립니다."),
+  PASSWORD_CHECK_INCORRECT(HttpStatus.BAD_REQUEST, "비밀번호 확인이 일치하지 않습니다."),
 
 
 
   //Security
   LOGIN_FAILED_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "계정이 존재하지 않습니다."),
-  LOGIN_FAILED_PASSWORD_INCORRECT(HttpStatus.UNAUTHORIZED, "비밀번호가 틀립니다."),
+  LOGIN_FAILED_PASSWORD_INCORRECT(HttpStatus.UNAUTHORIZED, "로그인에 실패하였씁니다. 비밀번호가 틀립니다."),
   ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
   LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, "로그인이 되지 않았습니다."),
 

--- a/src/test/java/com/blog/som/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/blog/som/domain/member/service/MemberServiceTest.java
@@ -9,6 +9,8 @@ import static org.mockito.Mockito.when;
 
 import com.blog.som.EntityCreator;
 import com.blog.som.domain.member.dto.EmailAuthResult;
+import com.blog.som.domain.member.dto.MemberDto;
+import com.blog.som.domain.member.dto.MemberEditRequest;
 import com.blog.som.domain.member.dto.MemberRegister;
 import com.blog.som.domain.member.dto.MemberRegister.Request;
 import com.blog.som.domain.member.dto.MemberRegister.Response;
@@ -152,6 +154,62 @@ class MemberServiceTest {
       assertThat(emailAuthResult.getMemberDto().getMemberId()).isEqualTo(1L);
     }
 
+  }
+
+  @Nested
+  @DisplayName("회원 정보 수정")
+  class EditMemberInfo{
+    @Test
+    @DisplayName("성공")
+    void editMemberInfo(){
+      MemberEntity member = EntityCreator.createMember(1L);
+
+      MemberEditRequest request = MemberEditRequest.builder()
+          .nickname("edit-nickname")
+          .birthDate(LocalDate.of(2020, 01, 01))
+          .phoneNumber("01011112222")
+          .build();
+
+      MemberEntity updatedMember = EntityCreator.createMember(1L);
+      updatedMember.setNickname(request.getNickname());
+      updatedMember.setBirthDate(request.getBirthDate());
+      updatedMember.setPhoneNumber(request.getPhoneNumber());
+
+      //given
+      when(memberRepository.findById(1L))
+          .thenReturn(Optional.of(member));
+      when(memberRepository.save(member))
+          .thenReturn(updatedMember);
+
+      //when
+      MemberDto result = memberService.editMemberInfo(1L, request);
+
+      //then
+      assertThat(result.getNickname()).isEqualTo(request.getNickname());
+      assertThat(result.getBirthDate()).isEqualTo(request.getBirthDate());
+      assertThat(result.getPhoneNumber()).isEqualTo(request.getPhoneNumber());
+    }
+
+    @Test
+    @DisplayName("실패 : MEMBER_NOT_FOUND")
+    void editMemberInfo_MEMBER_NOT_FOUND(){
+      MemberEditRequest request = MemberEditRequest.builder()
+          .nickname("edit-nickname")
+          .birthDate(LocalDate.of(2020, 01, 01))
+          .phoneNumber("01011112222")
+          .build();
+
+      //given
+      when(memberRepository.findById(1L))
+          .thenReturn(Optional.empty());
+
+      //when
+      //then
+      MemberException memberException =
+          assertThrows(MemberException.class, () -> memberService.editMemberInfo(1L, request));
+      assertThat(memberException.getErrorCode()).isEqualTo(ErrorCode.MEMBER_NOT_FOUND);
+
+    }
   }
 
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요.  -->
### [회원 정보 수정]
- 수정할 수 있는 정보는 `nickname`, `phoneNumber`, `birthDate` 3가지이다. (추후 추가 할수도 있음)
- 회원 정보 수정과 비밀번호 수정은 분리하였다.

### [비밀번호 수정]
- `현재 비밀번호`, `새 비밀번호`, `새 비밀번호 확인` 3가지 데이터를 입력받는다.
- 클라이언트측에서도 검증하겠지만, BE 단에서도 검증 한다.
- loginMember의 비밀번호와 입력받은 `현재 비밀번호`가 일치하는지 확인 후 `새 비밀번호`와 `새 비밀번호 확인`이 일치하는 지 확인한다.

---

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 

