### PR TITLE
Feat : 회원 프로필 사진 저장, 변경, 삭제 API 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,9 @@ dependencies {
     //mail
     implementation 'org.springframework.boot:spring-boot-starter-mail'
 
+    //s3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
     //swagger
     implementation 'io.springfox:springfox-boot-starter:3.0.0'
     implementation 'io.springfox:springfox-swagger-ui:3.0.0'

--- a/src/main/java/com/blog/som/TestController.java
+++ b/src/main/java/com/blog/som/TestController.java
@@ -11,6 +11,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -30,12 +31,21 @@ public class TestController {
       return ResponseEntity.ok(loginMember);
   }
 
-  @PostMapping("/s3")
+  @PostMapping("/s3/upload")
   public ResponseEntity<?> s3Upload(@RequestPart(value = "image", required = false) MultipartFile image){
     log.info("image : {}", image);
     String profileImage = s3Uploader.upload(image);
     return ResponseEntity.ok(profileImage);
   }
+
+  @GetMapping("/s3/delete")
+  public ResponseEntity<?> s3delete(@RequestParam String addr){
+      log.info("image address : {}", addr);
+      s3Uploader.deleteImageFromS3(addr);
+      return ResponseEntity.ok(null);
+  }
+
+
   
   
 }

--- a/src/main/java/com/blog/som/TestController.java
+++ b/src/main/java/com/blog/som/TestController.java
@@ -1,24 +1,40 @@
 package com.blog.som;
 
 import com.blog.som.domain.member.security.userdetails.LoginMember;
+import com.blog.som.global.s3.S3Uploader;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
+@Slf4j
 @Api(tags = "test용 컨트롤러 - security 오픈되어있음")
 @RequiredArgsConstructor
+@RestController
 @RequestMapping("/test")
 public class TestController {
+  private final S3Uploader s3Uploader;
   
   @ApiOperation(value = "로그인 멤버 확인", notes = "토큰만 Header에 포함시켜서 로그인 멤버 확인")
   @GetMapping("/loginUser")
   public ResponseEntity<?> loginUser(@AuthenticationPrincipal LoginMember loginMember){
       
       return ResponseEntity.ok(loginMember);
+  }
+
+  @PostMapping("/s3")
+  public ResponseEntity<?> s3Upload(@RequestPart(value = "image", required = false) MultipartFile image){
+    log.info("image : {}", image);
+    String profileImage = s3Uploader.upload(image);
+    return ResponseEntity.ok(profileImage);
   }
   
   

--- a/src/main/java/com/blog/som/TestController.java
+++ b/src/main/java/com/blog/som/TestController.java
@@ -1,7 +1,7 @@
 package com.blog.som;
 
 import com.blog.som.domain.member.security.userdetails.LoginMember;
-import com.blog.som.global.s3.S3Uploader;
+import com.blog.som.global.s3.S3ImageService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +22,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequestMapping("/test")
 public class TestController {
-  private final S3Uploader s3Uploader;
+  private final S3ImageService s3ImageService;
   
   @ApiOperation(value = "로그인 멤버 확인", notes = "토큰만 Header에 포함시켜서 로그인 멤버 확인")
   @GetMapping("/loginUser")
@@ -34,14 +34,14 @@ public class TestController {
   @PostMapping("/s3/upload")
   public ResponseEntity<?> s3Upload(@RequestPart(value = "image", required = false) MultipartFile image){
     log.info("image : {}", image);
-    String profileImage = s3Uploader.upload(image);
+    String profileImage = s3ImageService.upload(image);
     return ResponseEntity.ok(profileImage);
   }
 
   @GetMapping("/s3/delete")
   public ResponseEntity<?> s3delete(@RequestParam String addr){
       log.info("image address : {}", addr);
-      s3Uploader.deleteImageFromS3(addr);
+      s3ImageService.deleteImageFromS3(addr);
       return ResponseEntity.ok(null);
   }
 

--- a/src/main/java/com/blog/som/domain/member/controller/MemberController.java
+++ b/src/main/java/com/blog/som/domain/member/controller/MemberController.java
@@ -20,7 +20,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @Api(tags = "회원(Member)")
@@ -66,11 +68,12 @@ public class MemberController {
     return ResponseEntity.ok(response);
   }
 
-  @ApiOperation(value = "프로필 사진 변경(등록)", notes = "(TODO)기존의 것이 있으면 덮어쓰기")
+  @ApiOperation(value = "프로필 사진 변경(등록)", notes = "기존의 것이 있으면 덮어쓴다.")
   @PutMapping("/member/profile-image")
-  public ResponseEntity<?> editProfileImage(){
-
-    return ResponseEntity.ok(null);
+  public ResponseEntity<MemberDto> editProfileImage(@RequestPart(required = false) MultipartFile profileImage,
+      @AuthenticationPrincipal LoginMember loginMember){
+    MemberDto memberDto = memberService.updateProfileImage(loginMember.getMemberId(), profileImage);
+    return ResponseEntity.ok(memberDto);
   }
 
   @ApiOperation(value = "프로필 사진 삭제", notes = "(TODO)프로필 사진을 null로 수정")

--- a/src/main/java/com/blog/som/domain/member/controller/MemberController.java
+++ b/src/main/java/com/blog/som/domain/member/controller/MemberController.java
@@ -42,7 +42,7 @@ public class MemberController {
 
   @ApiOperation("이메일 인증")
   @GetMapping("/auth/email-auth")
-  public ResponseEntity<EmailAuthResult> emailAuth(@RequestParam String key){
+  public ResponseEntity<EmailAuthResult> emailAuth(@RequestParam String key) {
 
     EmailAuthResult emailAuthResult = memberService.emailAuth(key);
     return ResponseEntity.ok(emailAuthResult);
@@ -52,7 +52,7 @@ public class MemberController {
   @PutMapping("/member")
   public ResponseEntity<MemberDto> editMemberInfo(
       @RequestBody MemberEditRequest request,
-      @AuthenticationPrincipal LoginMember loginMember){
+      @AuthenticationPrincipal LoginMember loginMember) {
 
     MemberDto result = memberService.editMemberInfo(loginMember.getMemberId(), request);
     return ResponseEntity.ok(result);
@@ -62,7 +62,7 @@ public class MemberController {
   @PutMapping("/member/edit-password")
   public ResponseEntity<MemberPasswordEdit.Response> editMemberPassword(
       @RequestBody MemberPasswordEdit.Request request,
-      @AuthenticationPrincipal LoginMember loginMember){
+      @AuthenticationPrincipal LoginMember loginMember) {
     MemberPasswordEdit.Response response =
         memberService.editMemberPassword(loginMember.getMemberId(), request);
     return ResponseEntity.ok(response);
@@ -71,17 +71,15 @@ public class MemberController {
   @ApiOperation(value = "프로필 사진 변경(등록)", notes = "기존의 것이 있으면 덮어쓴다.")
   @PutMapping("/member/profile-image")
   public ResponseEntity<MemberDto> editProfileImage(@RequestPart(required = false) MultipartFile profileImage,
-      @AuthenticationPrincipal LoginMember loginMember){
+      @AuthenticationPrincipal LoginMember loginMember) {
     MemberDto memberDto = memberService.updateProfileImage(loginMember.getMemberId(), profileImage);
     return ResponseEntity.ok(memberDto);
   }
 
-  @ApiOperation(value = "프로필 사진 삭제", notes = "(TODO)프로필 사진을 null로 수정")
+  @ApiOperation(value = "프로필 사진 삭제", notes = "프로필 사진을 null로 수정")
   @DeleteMapping("/member/profile-image/remove")
-  public ResponseEntity<?> deleteProfileImage(){
-
-    return ResponseEntity.ok(null);
+  public ResponseEntity<MemberDto> deleteProfileImage(@AuthenticationPrincipal LoginMember loginMember) {
+    MemberDto memberDto = memberService.deleteProfileImage(loginMember.getMemberId());
+    return ResponseEntity.ok(memberDto);
   }
-
-
 }

--- a/src/main/java/com/blog/som/domain/member/service/MemberService.java
+++ b/src/main/java/com/blog/som/domain/member/service/MemberService.java
@@ -18,4 +18,6 @@ public interface MemberService {
   MemberPasswordEdit.Response editMemberPassword(Long memberId, MemberPasswordEdit.Request request);
 
   MemberDto updateProfileImage(Long memberId, MultipartFile profileImage);
+
+  MemberDto deleteProfileImage(Long memberId);
 }

--- a/src/main/java/com/blog/som/domain/member/service/MemberService.java
+++ b/src/main/java/com/blog/som/domain/member/service/MemberService.java
@@ -5,6 +5,7 @@ import com.blog.som.domain.member.dto.MemberDto;
 import com.blog.som.domain.member.dto.MemberEditRequest;
 import com.blog.som.domain.member.dto.MemberPasswordEdit;
 import com.blog.som.domain.member.dto.MemberRegister;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface MemberService {
 
@@ -15,4 +16,6 @@ public interface MemberService {
   MemberDto editMemberInfo(Long memberId, MemberEditRequest request);
 
   MemberPasswordEdit.Response editMemberPassword(Long memberId, MemberPasswordEdit.Request request);
+
+  MemberDto updateProfileImage(Long memberId, MultipartFile profileImage);
 }

--- a/src/main/java/com/blog/som/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/blog/som/domain/member/service/MemberServiceImpl.java
@@ -120,4 +120,20 @@ public class MemberServiceImpl implements MemberService {
 
     return MemberDto.fromEntity(member);
   }
+
+  @Override
+  public MemberDto deleteProfileImage(Long memberId) {
+    MemberEntity member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+
+    if(Objects.isNull(member.getProfileImage())){
+      return MemberDto.fromEntity(member);
+    }
+
+    s3ImageService.deleteImageFromS3(member.getProfileImage());
+    member.setProfileImage(null);
+    memberRepository.save(member);
+
+    return MemberDto.fromEntity(member);
+  }
 }

--- a/src/main/java/com/blog/som/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/blog/som/domain/member/service/MemberServiceImpl.java
@@ -16,10 +16,13 @@ import com.blog.som.global.constant.ResponseConstant;
 import com.blog.som.global.exception.ErrorCode;
 import com.blog.som.global.exception.custom.MemberException;
 import com.blog.som.global.redis.email.EmailAuthRepository;
+import com.blog.som.global.s3.S3ImageService;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -29,6 +32,7 @@ public class MemberServiceImpl implements MemberService {
   private final MemberRepository memberRepository;
   private final MailSender mailSender;
   private final EmailAuthRepository emailAuthRepository;
+  private final S3ImageService s3ImageService;
 
   @Override
   public Response registerMember(Request request) {
@@ -98,4 +102,22 @@ public class MemberServiceImpl implements MemberService {
     return new MemberPasswordEdit.Response(member.getMemberId(), ResponseConstant.PASSWORD_EDIT_COMPLETE);
   }
 
+  @Override
+  public MemberDto updateProfileImage(Long memberId, MultipartFile profileImage) {
+    MemberEntity member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+    if(profileImage.isEmpty()){
+      log.info("[updateProfileImage] - input image is Empty");
+      return MemberDto.fromEntity(member);
+    }
+
+    if(!Objects.isNull(member.getProfileImage())){
+      s3ImageService.deleteImageFromS3(member.getProfileImage());
+    }
+    String newImageAddress = s3ImageService.upload(profileImage);
+    member.setProfileImage(newImageAddress);
+    memberRepository.save(member);
+
+    return MemberDto.fromEntity(member);
+  }
 }

--- a/src/main/java/com/blog/som/global/config/S3Config.java
+++ b/src/main/java/com/blog/som/global/config/S3Config.java
@@ -1,0 +1,32 @@
+package com.blog.som.global.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+  @Value("${cloud.aws.credentials.accessKey}")
+  private String accessKey;
+  @Value("${cloud.aws.credentials.secretKey}")
+  private String secretKey;
+  @Value("${cloud.aws.region.static}")
+  private String region;
+
+  @Bean
+  public AmazonS3 awsS3Client() {
+    AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+    return AmazonS3ClientBuilder
+        .standard()
+        .withCredentials(new AWSStaticCredentialsProvider(credentials))
+        .withRegion(region)
+        .build();
+  }
+
+}

--- a/src/main/java/com/blog/som/global/config/S3Config.java
+++ b/src/main/java/com/blog/som/global/config/S3Config.java
@@ -19,7 +19,7 @@ public class S3Config {
   private String region;
 
   @Bean
-  public AmazonS3 awsS3Client() {
+  public AmazonS3 amazonS3() {
     AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
 
     return AmazonS3ClientBuilder

--- a/src/main/java/com/blog/som/global/exception/ErrorCode.java
+++ b/src/main/java/com/blog/som/global/exception/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
   INVALID_FILE_EXTENTION(HttpStatus.BAD_REQUEST, "유효하지 않은 파일 확장자 입니다."),
   PUT_OBJECT_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "Amazon S3에 파일을 업로드 하는데 실패했습니다."),
   IO_EXCEPTION_ON_IMAGE_UPLOAD(HttpStatus.INTERNAL_SERVER_ERROR, "image upload 도중 image.getInputStream() 또는 IOUtils.toByteArray(is)에서 에러가 발생했습니다."),
+  IO_EXCEPTION_ON_IMAGE_DELETE(HttpStatus.INTERNAL_SERVER_ERROR, "image 삭제 도중 IOException이 발생했습니다."),
 
 
   //Security

--- a/src/main/java/com/blog/som/global/exception/ErrorCode.java
+++ b/src/main/java/com/blog/som/global/exception/ErrorCode.java
@@ -17,6 +17,12 @@ public enum ErrorCode {
   MEMBER_PASSWORD_INCORRECT(HttpStatus.BAD_REQUEST, "비밀번호가 틀립니다."),
   PASSWORD_CHECK_INCORRECT(HttpStatus.BAD_REQUEST, "비밀번호 확인이 일치하지 않습니다."),
 
+  //S3 image upload
+  EMPTY_FILE_EXCEPTION(HttpStatus.BAD_REQUEST, "빈 파일 입니다."),
+  NO_FILE_EXTENTION(HttpStatus.BAD_REQUEST, "파일 확장자가 존재하지 않습니다."),
+  INVALID_FILE_EXTENTION(HttpStatus.BAD_REQUEST, "유효하지 않은 파일 확장자 입니다."),
+  PUT_OBJECT_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "Amazon S3에 파일을 업로드 하는데 실패했습니다."),
+  IO_EXCEPTION_ON_IMAGE_UPLOAD(HttpStatus.INTERNAL_SERVER_ERROR, "image upload 도중 image.getInputStream() 또는 IOUtils.toByteArray(is)에서 에러가 발생했습니다."),
 
 
   //Security

--- a/src/main/java/com/blog/som/global/exception/custom/S3Exception.java
+++ b/src/main/java/com/blog/som/global/exception/custom/S3Exception.java
@@ -1,0 +1,23 @@
+package com.blog.som.global.exception.custom;
+
+import com.blog.som.global.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+public class S3Exception extends RuntimeException{
+    private ErrorCode errorCode;
+    private String errorMessage;
+
+    public S3Exception(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+        this.errorMessage = errorCode.getDescription();
+    }
+}

--- a/src/main/java/com/blog/som/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/blog/som/global/exception/handler/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.blog.som.global.exception.ErrorCode;
 import com.blog.som.global.exception.ErrorResponse;
 import com.blog.som.global.exception.custom.MemberException;
 import com.blog.som.global.exception.custom.CustomSecurityException;
+import com.blog.som.global.exception.custom.S3Exception;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -22,6 +23,12 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler(MemberException.class)
   public ResponseEntity<ErrorResponse> handleMemberException(MemberException e) {
+    ErrorResponse errorResponse = new ErrorResponse(e.getErrorCode(), e.getErrorMessage());
+    return new ResponseEntity<>(errorResponse, e.getErrorCode().getStatus());
+  }
+
+  @ExceptionHandler(S3Exception.class)
+  public ResponseEntity<ErrorResponse> handleS3Exception(S3Exception e) {
     ErrorResponse errorResponse = new ErrorResponse(e.getErrorCode(), e.getErrorMessage());
     return new ResponseEntity<>(errorResponse, e.getErrorCode().getStatus());
   }

--- a/src/main/java/com/blog/som/global/s3/S3ImageService.java
+++ b/src/main/java/com/blog/som/global/s3/S3ImageService.java
@@ -28,7 +28,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Slf4j
 @RequiredArgsConstructor
 @Component
-public class S3Uploader {
+public class S3ImageService {
 
   private final AmazonS3 amazonS3;
 

--- a/src/main/java/com/blog/som/global/s3/S3Uploader.java
+++ b/src/main/java/com/blog/som/global/s3/S3Uploader.java
@@ -2,6 +2,7 @@ package com.blog.som.global.s3;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.util.IOUtils;
@@ -10,6 +11,10 @@ import com.blog.som.global.exception.custom.S3Exception;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLDecoder;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -87,5 +92,24 @@ public class S3Uploader {
     }
 
     return amazonS3.getUrl(bucketName, s3FileName).toString();
+  }
+
+  public void deleteImageFromS3(String imageAddress){
+    String key = getKeyFromImageAddress(imageAddress);
+    try{
+      amazonS3.deleteObject(new DeleteObjectRequest(bucketName, key));
+    }catch (Exception e){
+      throw new S3Exception(ErrorCode.IO_EXCEPTION_ON_IMAGE_DELETE);
+    }
+  }
+
+  private String getKeyFromImageAddress(String imageAddress){
+    try{
+      URL url = new URL(imageAddress);
+      String decodingKey = URLDecoder.decode(url.getPath(), "UTF-8");
+      return decodingKey.substring(1); // 맨 앞의 '/' 제거
+    }catch (MalformedURLException | UnsupportedEncodingException e){
+      throw new S3Exception(ErrorCode.IO_EXCEPTION_ON_IMAGE_DELETE);
+    }
   }
 }

--- a/src/main/java/com/blog/som/global/s3/S3Uploader.java
+++ b/src/main/java/com/blog/som/global/s3/S3Uploader.java
@@ -1,0 +1,91 @@
+package com.blog.som.global.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.util.IOUtils;
+import com.blog.som.global.exception.ErrorCode;
+import com.blog.som.global.exception.custom.S3Exception;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class S3Uploader {
+
+  private final AmazonS3 amazonS3;
+
+  @Value("${cloud.aws.s3.bucketName}")
+  private String bucketName;
+
+  public String upload(MultipartFile image) {
+    if(image.isEmpty() || Objects.isNull(image.getOriginalFilename())){
+      throw new S3Exception(ErrorCode.EMPTY_FILE_EXCEPTION);
+    }
+    return this.uploadImage(image);
+  }
+
+  private String uploadImage(MultipartFile image) {
+    this.validateImageFileExtention(image.getOriginalFilename());
+    try {
+      return this.uploadImageToS3(image);
+    } catch (IOException e) {
+      throw new S3Exception(ErrorCode.IO_EXCEPTION_ON_IMAGE_UPLOAD);
+    }
+  }
+
+  private void validateImageFileExtention(String filename) {
+    int lastDotIndex = filename.lastIndexOf(".");
+    if (lastDotIndex == -1) {
+      throw new S3Exception(ErrorCode.NO_FILE_EXTENTION);
+    }
+
+    String extention = filename.substring(lastDotIndex + 1).toLowerCase();
+    List<String> allowedExtentionList = Arrays.asList("jpg", "jpeg", "png", "gif");
+
+    if (!allowedExtentionList.contains(extention)) {
+      throw new S3Exception(ErrorCode.INVALID_FILE_EXTENTION);
+    }
+  }
+
+  private String uploadImageToS3(MultipartFile image) throws IOException {
+    String originalFilename = image.getOriginalFilename(); //원본 파일 명
+    String extention = originalFilename.substring(originalFilename.lastIndexOf(".")); //확장자 명
+
+    String s3FileName = UUID.randomUUID().toString().substring(0, 10) + originalFilename; //변경된 파일 명
+
+    InputStream is = image.getInputStream();
+    byte[] bytes = IOUtils.toByteArray(is);
+
+    ObjectMetadata metadata = new ObjectMetadata();
+    metadata.setContentType("image/" + extention);
+    metadata.setContentLength(bytes.length);
+    ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
+
+    try{
+      PutObjectRequest putObjectRequest =
+          new PutObjectRequest(bucketName, s3FileName, byteArrayInputStream, metadata)
+              .withCannedAcl(CannedAccessControlList.PublicRead);
+      amazonS3.putObject(putObjectRequest); // put image to S3
+    }catch (Exception e){
+      throw new S3Exception(ErrorCode.PUT_OBJECT_EXCEPTION);
+    }finally {
+      byteArrayInputStream.close();
+      is.close();
+    }
+
+    return amazonS3.getUrl(bucketName, s3FileName).toString();
+  }
+}

--- a/src/test/java/com/blog/som/EntityCreator.java
+++ b/src/test/java/com/blog/som/EntityCreator.java
@@ -15,6 +15,7 @@ public class EntityCreator {
         .nickname("nickname" + id)
         .phoneNumber("010" + id + "00" + "5678")
         .birthDate(LocalDate.now())
+        .profileImage("test-profile-image" + id + ".jpg")
         .registeredAt(LocalDateTime.now())
         .role(Role.USER)
         .build();


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요.  -->
### [S3]
-  S3Config에서 AmazonS3 빈 등록
- `S3ImageService`에서 AmazonS3 주입받아서 image upload, delete 기능 구현

### [profileImage upload]
- 기존 프로필 사진 존재 시 : 기존 프로필 사진 삭제 후 저장
- 기존 프로필 사진 null : 삭제는 건너뛰고 저장
- 요청 MultipartFile null : 아무런 동작하지않고 바로 MemberDto 반환

### [profileImage delete]
- 기존 프로필 사진 존재 시 :프로필 사진 삭제 후 `member.profileImage=null`로 수정
- 기존 프로필 사진 null : 아무런 동작하지않고 바로 MemberDto 반환



---

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 

