### PR TITLE
Feat : 게시글 작성 API 구현

### DIFF
--- a/src/main/java/com/blog/som/domain/post/controller/PostController.java
+++ b/src/main/java/com/blog/som/domain/post/controller/PostController.java
@@ -2,6 +2,7 @@ package com.blog.som.domain.post.controller;
 
 
 import com.blog.som.domain.member.security.userdetails.LoginMember;
+import com.blog.som.domain.post.dto.PostDto;
 import com.blog.som.domain.post.dto.PostWriteRequest;
 import com.blog.som.domain.post.service.PostService;
 import io.swagger.annotations.Api;
@@ -9,7 +10,7 @@ import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -21,11 +22,13 @@ public class PostController {
   private final PostService postService;
 
   @ApiOperation("게시글 작성")
-  @GetMapping("/write")
-  public ResponseEntity<?> writePost(@RequestBody PostWriteRequest request,
+  @PostMapping("/post")
+  public ResponseEntity<PostDto> writePost(@RequestBody PostWriteRequest request,
       @AuthenticationPrincipal LoginMember loginMember) {
 
-    return ResponseEntity.ok(null);
+    PostDto postDto = postService.writePost(request, loginMember.getMemberId());
+
+    return ResponseEntity.ok(postDto);
   }
 
 }

--- a/src/main/java/com/blog/som/domain/post/dto/PostDto.java
+++ b/src/main/java/com/blog/som/domain/post/dto/PostDto.java
@@ -1,0 +1,59 @@
+package com.blog.som.domain.post.dto;
+
+import com.blog.som.domain.post.entity.PostEntity;
+import java.time.LocalDateTime;
+import java.util.List;
+import javax.persistence.EntityListeners;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class PostDto {
+
+  private Long postId;
+
+  private Long memberId;
+
+  private String title;
+
+  private String content;
+
+  private String thumbnail;
+
+  private String introduction;
+
+  private int likes;
+
+  private int views;
+
+  private LocalDateTime registeredAt;
+
+  private LocalDateTime lastModifiedAt;
+
+  private List<String> tags;
+
+  public static PostDto fromEntity(PostEntity post, List<String> tagList) {
+    return PostDto.builder()
+        .postId(post.getPostId())
+        .memberId(post.getMember().getMemberId())
+        .title(post.getTitle())
+        .content(post.getContent())
+        .thumbnail(post.getThumbnail())
+        .introduction(post.getIntroduction())
+        .likes(post.getLikes())
+        .views(post.getViews())
+        .registeredAt(post.getRegisteredAt())
+        .lastModifiedAt(post.getLastModifiedAt())
+        .tags(tagList)
+        .build();
+  }
+}

--- a/src/main/java/com/blog/som/domain/post/dto/PostWriteRequest.java
+++ b/src/main/java/com/blog/som/domain/post/dto/PostWriteRequest.java
@@ -1,8 +1,41 @@
 package com.blog.som.domain.post.dto;
 
+import com.blog.som.domain.member.entity.MemberEntity;
+import com.blog.som.domain.post.entity.PostEntity;
+import java.time.LocalDateTime;
+import java.util.List;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
 public class PostWriteRequest {
 
+  private String title;
 
+  private String content;
+
+  private String thumbnail;
+
+  private String introduction;
+
+  private List<String> tags;
+
+  public static PostEntity toEntity(PostWriteRequest request, MemberEntity member){
+    return PostEntity.builder()
+        .member(member)
+        .title(request.getTitle())
+        .content(request.getContent())
+        .thumbnail(request.getThumbnail())
+        .introduction(request.getIntroduction())
+        .lastModifiedAt(LocalDateTime.now())
+        .build();
+  }
 }

--- a/src/main/java/com/blog/som/domain/post/entity/PostEntity.java
+++ b/src/main/java/com/blog/som/domain/post/entity/PostEntity.java
@@ -2,6 +2,7 @@ package com.blog.som.domain.post.entity;
 
 import com.blog.som.domain.member.entity.MemberEntity;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
@@ -61,4 +62,21 @@ public class PostEntity {
 
   @Column(name = "last_modified_at")
   private LocalDateTime lastModifiedAt;
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    PostEntity that = (PostEntity) o;
+    return Objects.equals(postId, that.postId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(postId);
+  }
 }

--- a/src/main/java/com/blog/som/domain/post/service/PostService.java
+++ b/src/main/java/com/blog/som/domain/post/service/PostService.java
@@ -1,6 +1,11 @@
 package com.blog.som.domain.post.service;
 
 
+import com.blog.som.domain.post.dto.PostDto;
+import com.blog.som.domain.post.dto.PostWriteRequest;
+
 public interface PostService {
+
+  PostDto writePost(PostWriteRequest request, Long memberId);
 
 }

--- a/src/main/java/com/blog/som/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/blog/som/domain/post/service/PostServiceImpl.java
@@ -1,14 +1,62 @@
 package com.blog.som.domain.post.service;
 
+import com.blog.som.domain.member.entity.MemberEntity;
+import com.blog.som.domain.member.repository.MemberRepository;
+import com.blog.som.domain.post.dto.PostDto;
+import com.blog.som.domain.post.dto.PostWriteRequest;
+import com.blog.som.domain.post.entity.PostEntity;
 import com.blog.som.domain.post.repository.PostRepository;
+import com.blog.som.domain.tag.entity.PostTagEntity;
+import com.blog.som.domain.tag.entity.TagEntity;
+import com.blog.som.domain.tag.repository.PostTagRepository;
+import com.blog.som.domain.tag.repository.TagRepository;
+import com.blog.som.global.exception.ErrorCode;
+import com.blog.som.global.exception.custom.MemberException;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @RequiredArgsConstructor
+@Transactional
 @Service
 public class PostServiceImpl implements PostService {
 
   private final PostRepository postRepository;
+  private final MemberRepository memberRepository;
+  private final TagRepository tagRepository;
+  private final PostTagRepository postTagRepository;
+
+  @Override
+  public PostDto writePost(PostWriteRequest request, Long memberId) {
+    MemberEntity member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+
+    PostEntity post = postRepository.save(PostWriteRequest.toEntity(request, member));
+
+    //tagList를 lower case로 변환
+    List<String> tagList = request.getTags().stream().map(String::toLowerCase).toList();
+
+    for (String tagName : tagList) {
+      Optional<TagEntity> optionalTag = tagRepository.findByTagNameAndMember(tagName, member);
+      TagEntity tagEntity;
+
+      //tagName이 이미 존재할 때 : 기존 tagEntity의 count + 1
+      if(optionalTag.isPresent()){
+        tagEntity = optionalTag.get();
+        tagEntity.addCount();
+      } //tagName이 존재하지 않을 때 : 새로운 tagEntity 저장
+      else {
+        tagEntity = new TagEntity(tagName, member);
+      }
+
+      tagRepository.save(tagEntity);
+      postTagRepository.save(new PostTagEntity(post, tagEntity));
+    }
+
+    return PostDto.fromEntity(post, tagList);
+  }
 }

--- a/src/main/java/com/blog/som/domain/tag/entity/PostTagEntity.java
+++ b/src/main/java/com/blog/som/domain/tag/entity/PostTagEntity.java
@@ -1,0 +1,43 @@
+package com.blog.som.domain.tag.entity;
+
+import com.blog.som.domain.post.entity.PostEntity;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "post_tag")
+public class PostTagEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "post_tag_id", nullable = false)
+  private Long postTagId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "post_id", nullable = false)
+  private PostEntity post;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "tag_id", nullable = false)
+  private TagEntity tag;
+
+  public PostTagEntity(PostEntity post, TagEntity tag) {
+    this.post = post;
+    this.tag = tag;
+  }
+}

--- a/src/main/java/com/blog/som/domain/tag/entity/TagEntity.java
+++ b/src/main/java/com/blog/som/domain/tag/entity/TagEntity.java
@@ -1,7 +1,6 @@
 package com.blog.som.domain.tag.entity;
 
 import com.blog.som.domain.member.entity.MemberEntity;
-import com.blog.som.domain.post.entity.PostEntity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
@@ -36,14 +35,19 @@ public class TagEntity {
   @JoinColumn(name = "member_id", nullable = false)
   private MemberEntity member;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "post_id", nullable = false)
-  private PostEntity post;
-
   @Column(name = "tag_name")
   private String tagName;
 
   @Column(name = "count")
   private int count;
 
+  public void addCount(){
+    this.count += 1;
+  }
+
+  public TagEntity(String tagName, MemberEntity member) {
+    this.member = member;
+    this.tagName = tagName;
+    this.count = 1;
+  }
 }

--- a/src/main/java/com/blog/som/domain/tag/repository/PostTagRepository.java
+++ b/src/main/java/com/blog/som/domain/tag/repository/PostTagRepository.java
@@ -1,0 +1,10 @@
+package com.blog.som.domain.tag.repository;
+
+import com.blog.som.domain.tag.entity.PostTagEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostTagRepository extends JpaRepository<PostTagEntity, Long> {
+
+}

--- a/src/main/java/com/blog/som/domain/tag/repository/TagRepository.java
+++ b/src/main/java/com/blog/som/domain/tag/repository/TagRepository.java
@@ -1,10 +1,14 @@
 package com.blog.som.domain.tag.repository;
 
+import com.blog.som.domain.member.entity.MemberEntity;
 import com.blog.som.domain.tag.entity.TagEntity;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface TagRepository extends JpaRepository<TagEntity, Long> {
+
+  Optional<TagEntity> findByTagNameAndMember(String tagName, MemberEntity member);
 
 }

--- a/src/test/java/com/blog/som/EntityCreator.java
+++ b/src/test/java/com/blog/som/EntityCreator.java
@@ -2,7 +2,9 @@ package com.blog.som;
 
 import com.blog.som.domain.member.entity.MemberEntity;
 import com.blog.som.domain.member.type.Role;
-import java.time.LocalDate;
+import com.blog.som.domain.post.entity.PostEntity;
+import com.blog.som.domain.tag.entity.PostTagEntity;
+import com.blog.som.domain.tag.entity.TagEntity;
 import java.time.LocalDateTime;
 
 public class EntityCreator {
@@ -20,5 +22,30 @@ public class EntityCreator {
         .registeredAt(LocalDateTime.now())
         .role(Role.USER)
         .build();
+  }
+
+  public static PostEntity createPost(Long id, MemberEntity member) {
+    return PostEntity.builder()
+        .postId(id)
+        .member(member)
+        .title("test-title" + id)
+        .content("test-content" + id)
+        .thumbnail("test-thumbnail" + id + ".jpg")
+        .introduction("test-introduction" + id)
+        .likes(0)
+        .views(0)
+        .registeredAt(LocalDateTime.now())
+        .lastModifiedAt(LocalDateTime.now())
+        .build();
+  }
+
+  public static TagEntity createTag(Long id, String tagName, MemberEntity member) {
+    TagEntity tagEntity = new TagEntity(tagName, member);
+    tagEntity.setTagId(id);
+    return tagEntity;
+  }
+
+  public static PostTagEntity createPostTag(Long id) {
+    return PostTagEntity.builder().build();
   }
 }

--- a/src/test/java/com/blog/som/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/blog/som/domain/post/service/PostServiceTest.java
@@ -1,0 +1,119 @@
+package com.blog.som.domain.post.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import com.blog.som.EntityCreator;
+import com.blog.som.domain.member.entity.MemberEntity;
+import com.blog.som.domain.member.repository.MemberRepository;
+import com.blog.som.domain.post.dto.PostDto;
+import com.blog.som.domain.post.dto.PostWriteRequest;
+import com.blog.som.domain.post.entity.PostEntity;
+import com.blog.som.domain.post.repository.PostRepository;
+import com.blog.som.domain.tag.entity.TagEntity;
+import com.blog.som.domain.tag.repository.PostTagRepository;
+import com.blog.som.domain.tag.repository.TagRepository;
+import com.blog.som.global.exception.ErrorCode;
+import com.blog.som.global.exception.custom.MemberException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@Slf4j
+@ExtendWith(MockitoExtension.class)
+class PostServiceTest {
+
+  @Mock
+  private PostRepository postRepository;
+  @Mock
+  private MemberRepository memberRepository;
+  @Mock
+  private TagRepository tagRepository;
+  @Mock
+  private PostTagRepository postTagRepository;
+
+  @InjectMocks
+  private PostServiceImpl postService;
+
+  @Nested
+  @DisplayName("게시글 작성")
+  class WritePost{
+
+    static String TAG_1 = "tag1";
+    static String TAG_2 = "tag2";
+
+    private PostWriteRequest createRequest(int id, List<String> tagList){
+      return PostWriteRequest.builder()
+          .title("test-title" + id)
+          .content("test-content" + id)
+          .thumbnail("test-thumbnail" + id + ".jpg")
+          .introduction("test-introduction" + id)
+          .tags(tagList)
+          .build();
+    }
+
+    @Test
+    @DisplayName("성공")
+    void writePost(){
+      MemberEntity member = EntityCreator.createMember(1L);
+      PostEntity post = EntityCreator.createPost(10L, member);
+
+      List<String> tagList = new ArrayList<>(Arrays.asList(TAG_1,TAG_2));
+      PostWriteRequest request = createRequest(10, tagList);
+
+      TagEntity tag1 = EntityCreator.createTag(100L, TAG_1, member);
+      TagEntity tag2 = EntityCreator.createTag(101L, TAG_2, member);
+
+      //given
+      when(memberRepository.findById(1L))
+          .thenReturn(Optional.of(member));
+      when(postRepository.save(PostWriteRequest.toEntity(request, member)))
+          .thenReturn(post);
+      when(tagRepository.findByTagNameAndMember(tagList.get(0), member))
+          .thenReturn(Optional.of(tag1));
+      when(tagRepository.findByTagNameAndMember(tagList.get(1), member))
+          .thenReturn(Optional.empty());
+
+      //when
+      PostDto result = postService.writePost(request, 1L);
+
+      //then
+      assertThat(result.getTitle()).isEqualTo(request.getTitle());
+      assertThat(result.getContent()).isEqualTo(request.getContent());
+      assertThat(result.getTags()).containsAll(tagList);
+    }
+
+    @Test
+    @DisplayName("실패 : MEMBER_NOT_FOUND")
+    void writePos_MEMBER_NOT_FOUND(){
+      MemberEntity member = EntityCreator.createMember(1L);
+
+      List<String> tagList = new ArrayList<>(Arrays.asList(TAG_1,TAG_2));
+      PostWriteRequest request = createRequest(10, tagList);
+
+      //given
+      when(memberRepository.findById(1L))
+          .thenReturn(Optional.empty());
+
+      //when
+      //then
+      MemberException memberException =
+          assertThrows(MemberException.class, () -> postService.writePost(request, 1L));
+      assertThat(memberException.getErrorCode()).isEqualTo(ErrorCode.MEMBER_NOT_FOUND);
+    }
+
+  }
+
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요.  -->
### [Tag 엔티티 분리]
- 기존 TagEntity를 `TagEntity`와` PostTagEntity`로 분리하였다.
- TagEntity : 어떤 `member`가 특정 `tagName`을 몇 개 가지고 있는지 확인하기 위함
- PostTagEntity : 특정 `post`에 어떤 `tag`가 달렸는지 확인하기 위함

### [게시글 작성 API]
- `tag`는 모두 `lowerCase`로 저장한다.
- 작성자가 해당 tag로 글을 쓴적이 있는지 확인하고, `Optional<TagEntity>`값으로 확인 
    - `isPresent()`의 경우 : `get()`으로 불러온 뒤 해당 `tagEntity`의 count를 1 증가시킨다.
    - `Optional.empty()`의 경우 : 새로운 `tagEntity`를 생성한다.
- 두가지 경우 모두 변경 또는 생성 된 `tagEntity`를 저장한다.
- 게시글과 태그를 매핑해줄 `PostTagEntity`도 생성하여 저장한다.  

(추가 정보)
- 클라이언트 측에서 이미지를 S3에 업로드하여 public url을 받는 API를 이용하기 때문에 `thumbnail`에는 imageAddress가 들어온다.
- postDto에는 post 정보와, post에 달린 tag list가 반환된다.
- `TagEntity`는 특정 회원이 해당 태그를 단 글을 몇개 작성하였는지 확인하는데 사용
- `PostTagEntity`는 게시글과 태그를 매핑하는데 사용

---

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 

