### PR TITLE
Feat : 게시글(post) CRUD

### DIFF
--- a/src/main/java/com/blog/som/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/blog/som/domain/member/service/MemberServiceImpl.java
@@ -13,7 +13,7 @@ import com.blog.som.global.components.password.PasswordUtils;
 import com.blog.som.global.constant.ResponseConstant;
 import com.blog.som.global.exception.ErrorCode;
 import com.blog.som.global.exception.custom.MemberException;
-import com.blog.som.global.redis.email.EmailAuthRepository;
+import com.blog.som.global.redis.email.CacheRepository;
 import com.blog.som.global.s3.S3ImageService;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
@@ -28,7 +28,7 @@ public class MemberServiceImpl implements MemberService {
 
   private final MemberRepository memberRepository;
   private final MailSender mailSender;
-  private final EmailAuthRepository emailAuthRepository;
+  private final CacheRepository cacheRepository;
   private final S3ImageService s3ImageService;
 
   @Override
@@ -44,7 +44,7 @@ public class MemberServiceImpl implements MemberService {
   @Override
   public MemberDto registerMember(Request request, String code) {
 
-    String email = emailAuthRepository.getEmailByUuid(code);
+    String email = cacheRepository.getEmailByUuid(code);
 
     if (memberRepository.existsByEmail(email)) {
       throw new MemberException(ErrorCode.EMAIL_AUTH_ALREADY_COMPLETE);

--- a/src/main/java/com/blog/som/domain/post/controller/PostController.java
+++ b/src/main/java/com/blog/som/domain/post/controller/PostController.java
@@ -10,6 +10,8 @@ import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,6 +29,15 @@ public class PostController {
       @AuthenticationPrincipal LoginMember loginMember) {
 
     PostDto postDto = postService.writePost(request, loginMember.getMemberId());
+
+    return ResponseEntity.ok(postDto);
+  }
+
+  @ApiOperation("게시글 조회")
+  @GetMapping("/post/{postId}")
+  public ResponseEntity<PostDto> getPost(@PathVariable Long postId){
+
+    PostDto postDto = postService.getPost(postId);
 
     return ResponseEntity.ok(postDto);
   }

--- a/src/main/java/com/blog/som/domain/post/controller/PostController.java
+++ b/src/main/java/com/blog/som/domain/post/controller/PostController.java
@@ -2,6 +2,7 @@ package com.blog.som.domain.post.controller;
 
 
 import com.blog.som.domain.member.security.userdetails.LoginMember;
+import com.blog.som.domain.post.dto.PostDeleteResponse;
 import com.blog.som.domain.post.dto.PostDto;
 import com.blog.som.domain.post.dto.PostEditRequest;
 import com.blog.som.domain.post.dto.PostWriteRequest;
@@ -12,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -58,5 +60,17 @@ public class PostController {
 
     return ResponseEntity.ok(postDto);
   }
+
+  @ApiOperation("게시글 삭제")
+  @DeleteMapping("/post/{postId}")
+  public ResponseEntity<PostDeleteResponse> deletePost(@PathVariable Long postId,
+      @AuthenticationPrincipal LoginMember loginMember){
+
+    PostDeleteResponse response = postService.deletePost(postId, loginMember.getMemberId());
+
+    return ResponseEntity.ok(response);
+  }
+
+
 
 }

--- a/src/main/java/com/blog/som/domain/post/controller/PostController.java
+++ b/src/main/java/com/blog/som/domain/post/controller/PostController.java
@@ -7,15 +7,19 @@ import com.blog.som.domain.post.dto.PostWriteRequest;
 import com.blog.som.domain.post.service.PostService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @Api(tags = "게시글(post)")
 @RequiredArgsConstructor
 @RestController
@@ -35,9 +39,10 @@ public class PostController {
 
   @ApiOperation("게시글 조회")
   @GetMapping("/post/{postId}")
-  public ResponseEntity<PostDto> getPost(@PathVariable Long postId){
+  public ResponseEntity<PostDto> getPost(@PathVariable Long postId,
+      @RequestHeader(value = "Custom-Access-User", defaultValue = "") String accessUserAgent){
 
-    PostDto postDto = postService.getPost(postId);
+    PostDto postDto = postService.getPost(postId, accessUserAgent);
 
     return ResponseEntity.ok(postDto);
   }

--- a/src/main/java/com/blog/som/domain/post/controller/PostController.java
+++ b/src/main/java/com/blog/som/domain/post/controller/PostController.java
@@ -3,11 +3,11 @@ package com.blog.som.domain.post.controller;
 
 import com.blog.som.domain.member.security.userdetails.LoginMember;
 import com.blog.som.domain.post.dto.PostDto;
+import com.blog.som.domain.post.dto.PostEditRequest;
 import com.blog.som.domain.post.dto.PostWriteRequest;
 import com.blog.som.domain.post.service.PostService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
-import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +15,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
@@ -43,6 +44,17 @@ public class PostController {
       @RequestHeader(value = "Custom-Access-User", defaultValue = "") String accessUserAgent){
 
     PostDto postDto = postService.getPost(postId, accessUserAgent);
+
+    return ResponseEntity.ok(postDto);
+  }
+
+  @ApiOperation("게시글 수정")
+  @PutMapping("/post/{postId}")
+  public ResponseEntity<PostDto> editPost(@PathVariable Long postId,
+      @RequestBody PostEditRequest postEditRequest,
+      @AuthenticationPrincipal LoginMember loginMember){
+
+    PostDto postDto = postService.editPost(postEditRequest, postId, loginMember.getMemberId());
 
     return ResponseEntity.ok(postDto);
   }

--- a/src/main/java/com/blog/som/domain/post/dto/PostDeleteResponse.java
+++ b/src/main/java/com/blog/som/domain/post/dto/PostDeleteResponse.java
@@ -1,0 +1,16 @@
+package com.blog.som.domain.post.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class PostDeleteResponse {
+  private Long postId;
+  private String postTitle;
+
+}

--- a/src/main/java/com/blog/som/domain/post/dto/PostEditRequest.java
+++ b/src/main/java/com/blog/som/domain/post/dto/PostEditRequest.java
@@ -1,0 +1,24 @@
+package com.blog.som.domain.post.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class PostEditRequest {
+
+  private String title;
+
+  private String content;
+
+  private String thumbnail;
+
+  private String introduction;
+
+  private List<String> tags;
+}

--- a/src/main/java/com/blog/som/domain/post/dto/PostEditRequest.java
+++ b/src/main/java/com/blog/som/domain/post/dto/PostEditRequest.java
@@ -2,6 +2,7 @@ package com.blog.som.domain.post.dto;
 
 import java.util.List;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -10,6 +11,7 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 public class PostEditRequest {
 
   private String title;

--- a/src/main/java/com/blog/som/domain/post/entity/PostEntity.java
+++ b/src/main/java/com/blog/som/domain/post/entity/PostEntity.java
@@ -63,6 +63,10 @@ public class PostEntity {
   @Column(name = "last_modified_at")
   private LocalDateTime lastModifiedAt;
 
+  public void addView(){
+    this.views += 1;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/src/main/java/com/blog/som/domain/post/entity/PostEntity.java
+++ b/src/main/java/com/blog/som/domain/post/entity/PostEntity.java
@@ -1,6 +1,7 @@
 package com.blog.som.domain.post.entity;
 
 import com.blog.som.domain.member.entity.MemberEntity;
+import com.blog.som.domain.post.dto.PostEditRequest;
 import java.time.LocalDateTime;
 import java.util.Objects;
 import javax.persistence.Column;
@@ -65,6 +66,13 @@ public class PostEntity {
 
   public void addView(){
     this.views += 1;
+  }
+
+  public void editPost(PostEditRequest request){
+    this.title = request.getTitle();
+    this.content = request.getContent();
+    this.thumbnail = request.getThumbnail();
+    this.introduction = request.getIntroduction();
   }
 
   @Override

--- a/src/main/java/com/blog/som/domain/post/service/PostService.java
+++ b/src/main/java/com/blog/som/domain/post/service/PostService.java
@@ -8,6 +8,6 @@ public interface PostService {
 
   PostDto writePost(PostWriteRequest request, Long memberId);
 
-  PostDto getPost(Long postId);
+  PostDto getPost(Long postId, String accessUserAgent);
 
 }

--- a/src/main/java/com/blog/som/domain/post/service/PostService.java
+++ b/src/main/java/com/blog/som/domain/post/service/PostService.java
@@ -1,6 +1,7 @@
 package com.blog.som.domain.post.service;
 
 
+import com.blog.som.domain.post.dto.PostDeleteResponse;
 import com.blog.som.domain.post.dto.PostDto;
 import com.blog.som.domain.post.dto.PostEditRequest;
 import com.blog.som.domain.post.dto.PostWriteRequest;
@@ -12,5 +13,7 @@ public interface PostService {
   PostDto getPost(Long postId, String accessUserAgent);
 
   PostDto editPost(PostEditRequest postEditRequest, Long postId, Long loginMemberId);
+
+  PostDeleteResponse deletePost(Long postId, Long loginMemberId);
 
 }

--- a/src/main/java/com/blog/som/domain/post/service/PostService.java
+++ b/src/main/java/com/blog/som/domain/post/service/PostService.java
@@ -8,4 +8,6 @@ public interface PostService {
 
   PostDto writePost(PostWriteRequest request, Long memberId);
 
+  PostDto getPost(Long postId);
+
 }

--- a/src/main/java/com/blog/som/domain/post/service/PostService.java
+++ b/src/main/java/com/blog/som/domain/post/service/PostService.java
@@ -2,6 +2,7 @@ package com.blog.som.domain.post.service;
 
 
 import com.blog.som.domain.post.dto.PostDto;
+import com.blog.som.domain.post.dto.PostEditRequest;
 import com.blog.som.domain.post.dto.PostWriteRequest;
 
 public interface PostService {
@@ -9,5 +10,7 @@ public interface PostService {
   PostDto writePost(PostWriteRequest request, Long memberId);
 
   PostDto getPost(Long postId, String accessUserAgent);
+
+  PostDto editPost(PostEditRequest postEditRequest, Long postId, Long loginMemberId);
 
 }

--- a/src/main/java/com/blog/som/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/blog/som/domain/post/service/PostServiceImpl.java
@@ -3,6 +3,7 @@ package com.blog.som.domain.post.service;
 import com.blog.som.domain.member.entity.MemberEntity;
 import com.blog.som.domain.member.repository.MemberRepository;
 import com.blog.som.domain.post.dto.PostDto;
+import com.blog.som.domain.post.dto.PostEditRequest;
 import com.blog.som.domain.post.dto.PostWriteRequest;
 import com.blog.som.domain.post.entity.PostEntity;
 import com.blog.som.domain.post.repository.PostRepository;
@@ -14,7 +15,9 @@ import com.blog.som.global.exception.ErrorCode;
 import com.blog.som.global.exception.custom.MemberException;
 import com.blog.som.global.exception.custom.PostException;
 import com.blog.som.global.redis.email.CacheRepository;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -44,22 +47,7 @@ public class PostServiceImpl implements PostService {
     //tagList를 lower case로 변환
     List<String> tagList = request.getTags().stream().map(String::toLowerCase).toList();
 
-    for (String tagName : tagList) {
-      Optional<TagEntity> optionalTag = tagRepository.findByTagNameAndMember(tagName, member);
-      TagEntity tagEntity;
-
-      //tagName이 이미 존재할 때 : 기존 tagEntity의 count + 1
-      if (optionalTag.isPresent()) {
-        tagEntity = optionalTag.get();
-        tagEntity.addCount();
-      } //tagName이 존재하지 않을 때 : 새로운 tagEntity 저장
-      else {
-        tagEntity = new TagEntity(tagName, member);
-      }
-
-      tagRepository.save(tagEntity);
-      postTagRepository.save(new PostTagEntity(post, tagEntity));
-    }
+    this.handleNewTags(tagList, member, post);
 
     return PostDto.fromEntity(post, tagList);
   }
@@ -81,4 +69,67 @@ public class PostServiceImpl implements PostService {
 
     return PostDto.fromEntity(post, tagList);
   }
+
+  @Override
+  public PostDto editPost(PostEditRequest postEditRequest, Long postId, Long loginMemberId) {
+    PostEntity post = postRepository.findById(postId)
+        .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
+    MemberEntity member = post.getMember();
+
+    if(!Objects.equals(member.getMemberId(), loginMemberId)){
+      throw new PostException(ErrorCode.POST_EDIT_NO_AUTHORITY);
+    }
+
+    post.editPost(postEditRequest);
+    postRepository.save(post);
+
+    List<String> requestList = postEditRequest.getTags().stream().map(String::toLowerCase).toList();
+    List<String> editRequestTags = new ArrayList<>(requestList);
+
+    for (PostTagEntity postTag : postTagRepository.findAllByPost(post)) {
+      //DB에도 있고, request에도 있는 경우 ( 그대로 인 경우 )
+      String currentTagName = postTag.getTag().getTagName();
+      if(editRequestTags.contains(currentTagName)){
+        editRequestTags.remove(currentTagName);
+        continue;
+      }
+
+      //DB에는 있지만, request에 없는 경우 ( 기존 Entity 삭제 )
+      postTagRepository.delete(postTag);//Tag보다 PostTag를 항상 먼저 삭제해야 한다.
+      TagEntity currentTag = postTag.getTag();
+
+      if(currentTag.getCount() <= 1){
+        tagRepository.delete(currentTag);
+      }else{
+        currentTag.minusCount();
+        tagRepository.save(currentTag);
+      }
+
+    }
+
+    this.handleNewTags(editRequestTags, member, post);
+
+    return PostDto.fromEntity(post, requestList);
+  }
+
+  private void handleNewTags(List<String> tagList, MemberEntity member, PostEntity post) {
+    for (String tagName : tagList) {
+      Optional<TagEntity> optionalTag = tagRepository.findByTagNameAndMember(tagName, member);
+      TagEntity tagEntity;
+
+      //tagName이 이미 존재할 때 : 기존 tagEntity의 count + 1
+      if (optionalTag.isPresent()) {
+        tagEntity = optionalTag.get();
+        tagEntity.addCount();
+      } //tagName이 존재하지 않을 때 : 새로운 tagEntity 저장
+      else {
+        tagEntity = new TagEntity(tagName, member);
+      }
+
+      tagRepository.save(tagEntity);
+      postTagRepository.save(new PostTagEntity(post, tagEntity));
+    }
+
+  }
+
 }

--- a/src/main/java/com/blog/som/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/blog/som/domain/post/service/PostServiceImpl.java
@@ -12,6 +12,7 @@ import com.blog.som.domain.tag.repository.PostTagRepository;
 import com.blog.som.domain.tag.repository.TagRepository;
 import com.blog.som.global.exception.ErrorCode;
 import com.blog.som.global.exception.custom.MemberException;
+import com.blog.som.global.exception.custom.PostException;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -45,7 +46,7 @@ public class PostServiceImpl implements PostService {
       TagEntity tagEntity;
 
       //tagName이 이미 존재할 때 : 기존 tagEntity의 count + 1
-      if(optionalTag.isPresent()){
+      if (optionalTag.isPresent()) {
         tagEntity = optionalTag.get();
         tagEntity.addCount();
       } //tagName이 존재하지 않을 때 : 새로운 tagEntity 저장
@@ -56,6 +57,19 @@ public class PostServiceImpl implements PostService {
       tagRepository.save(tagEntity);
       postTagRepository.save(new PostTagEntity(post, tagEntity));
     }
+
+    return PostDto.fromEntity(post, tagList);
+  }
+
+  @Override
+  public PostDto getPost(Long postId) {
+    PostEntity post = postRepository.findById(postId)
+        .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
+
+    List<String> tagList = postTagRepository.findAllByPost(post)
+        .stream()
+        .map(pt -> pt.getTag().getTagName())
+        .toList();
 
     return PostDto.fromEntity(post, tagList);
   }

--- a/src/main/java/com/blog/som/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/blog/som/domain/post/service/PostServiceImpl.java
@@ -106,7 +106,7 @@ public class PostServiceImpl implements PostService {
       }
 
     }
-
+    log.info("[PostService.editPost()] remain List tags : {} ", editRequestTags);
     this.handleNewTags(editRequestTags, member, post);
 
     return PostDto.fromEntity(post, requestList);

--- a/src/main/java/com/blog/som/domain/tag/entity/PostTagEntity.java
+++ b/src/main/java/com/blog/som/domain/tag/entity/PostTagEntity.java
@@ -32,7 +32,7 @@ public class PostTagEntity {
   @JoinColumn(name = "post_id", nullable = false)
   private PostEntity post;
 
-  @ManyToOne(fetch = FetchType.LAZY)
+  @ManyToOne(fetch = FetchType.EAGER)
   @JoinColumn(name = "tag_id", nullable = false)
   private TagEntity tag;
 

--- a/src/main/java/com/blog/som/domain/tag/entity/PostTagEntity.java
+++ b/src/main/java/com/blog/som/domain/tag/entity/PostTagEntity.java
@@ -1,6 +1,7 @@
 package com.blog.som.domain.tag.entity;
 
 import com.blog.som.domain.post.entity.PostEntity;
+import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -39,5 +40,22 @@ public class PostTagEntity {
   public PostTagEntity(PostEntity post, TagEntity tag) {
     this.post = post;
     this.tag = tag;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    PostTagEntity postTag = (PostTagEntity) o;
+    return Objects.equals(postTagId, postTag.postTagId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(postTagId);
   }
 }

--- a/src/main/java/com/blog/som/domain/tag/entity/TagEntity.java
+++ b/src/main/java/com/blog/som/domain/tag/entity/TagEntity.java
@@ -45,6 +45,10 @@ public class TagEntity {
     this.count += 1;
   }
 
+  public void minusCount(){
+    this.count -= 1;
+  }
+
   public TagEntity(String tagName, MemberEntity member) {
     this.member = member;
     this.tagName = tagName;

--- a/src/main/java/com/blog/som/domain/tag/repository/PostTagRepository.java
+++ b/src/main/java/com/blog/som/domain/tag/repository/PostTagRepository.java
@@ -1,10 +1,13 @@
 package com.blog.som.domain.tag.repository;
 
+import com.blog.som.domain.post.entity.PostEntity;
 import com.blog.som.domain.tag.entity.PostTagEntity;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostTagRepository extends JpaRepository<PostTagEntity, Long> {
 
+  List<PostTagEntity> findAllByPost(PostEntity post);
 }

--- a/src/main/java/com/blog/som/global/components/mail/MailSender.java
+++ b/src/main/java/com/blog/som/global/components/mail/MailSender.java
@@ -1,6 +1,6 @@
 package com.blog.som.global.components.mail;
 
-import com.blog.som.global.redis.email.EmailAuthRepository;
+import com.blog.som.global.redis.email.CacheRepository;
 import javax.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
 public class MailSender {
 
   private final JavaMailSender javaMailSender;
-  private final EmailAuthRepository emailAuthRepository;
+  private final CacheRepository cacheRepository;
 
   @Async
   public void sendMailForRegister(SendMailDto sendMailDto) {
@@ -32,7 +32,7 @@ public class MailSender {
         .toString();
 
     //Redis 에 저장 (timeout = 10분)
-    emailAuthRepository.saveEmailAuthUuid(sendMailDto.getCode(), sendMailDto.getEmail());
+    cacheRepository.saveEmailAuthUuid(sendMailDto.getCode(), sendMailDto.getEmail());
 
     this.sendMail(mail, subject, text);
     log.info("메일 전송 완료 - {}", mail);

--- a/src/main/java/com/blog/som/global/constant/TimeConstant.java
+++ b/src/main/java/com/blog/som/global/constant/TimeConstant.java
@@ -5,4 +5,6 @@ public class TimeConstant {
   private TimeConstant(){}
 
   public static final Long EMAIL_AUTH_MINUTE = 10L;
+
+  public static final Long ADD_VIEW_MINUTE = 30L;
 }

--- a/src/main/java/com/blog/som/global/exception/ErrorCode.java
+++ b/src/main/java/com/blog/som/global/exception/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode{
 
   //Post 관련
   POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다."),
+  POST_EDIT_NO_AUTHORITY(HttpStatus.FORBIDDEN, "게시글 수정 권한이 없습니다."),
 
   //S3 image upload
   EMPTY_FILE_EXCEPTION(HttpStatus.BAD_REQUEST, "빈 파일 입니다."),

--- a/src/main/java/com/blog/som/global/exception/ErrorCode.java
+++ b/src/main/java/com/blog/som/global/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode{
   //Post 관련
   POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다."),
   POST_EDIT_NO_AUTHORITY(HttpStatus.FORBIDDEN, "게시글 수정 권한이 없습니다."),
+  POST_DELETE_NO_AUTHORITY(HttpStatus.FORBIDDEN, "게시글 삭제 권한이 없습니다."),
 
   //S3 image upload
   EMPTY_FILE_EXCEPTION(HttpStatus.BAD_REQUEST, "빈 파일 입니다."),

--- a/src/main/java/com/blog/som/global/exception/ErrorCode.java
+++ b/src/main/java/com/blog/som/global/exception/ErrorCode.java
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
-public enum ErrorCode {
+public enum ErrorCode{
   //Member 관련
   MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다."),
   EMAIL_AUTH_TIME_OUT(HttpStatus.BAD_REQUEST, "이메일 인증 키가 만료되었거나, 잘못된 요청 입니다."),
@@ -14,6 +14,9 @@ public enum ErrorCode {
   MEMBER_PASSWORD_INCORRECT(HttpStatus.BAD_REQUEST, "비밀번호가 틀립니다."),
   PASSWORD_CHECK_INCORRECT(HttpStatus.BAD_REQUEST, "비밀번호 확인이 일치하지 않습니다."),
   ACCOUNT_NAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 계정 명 입니다."),
+
+  //Post 관련
+  POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다."),
 
   //S3 image upload
   EMPTY_FILE_EXCEPTION(HttpStatus.BAD_REQUEST, "빈 파일 입니다."),

--- a/src/main/java/com/blog/som/global/exception/custom/PostException.java
+++ b/src/main/java/com/blog/som/global/exception/custom/PostException.java
@@ -1,0 +1,23 @@
+package com.blog.som.global.exception.custom;
+
+import com.blog.som.global.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+public class PostException extends RuntimeException{
+    private ErrorCode errorCode;
+    private String errorMessage;
+
+    public PostException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+        this.errorMessage = errorCode.getDescription();
+    }
+}

--- a/src/main/java/com/blog/som/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/blog/som/global/exception/handler/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.blog.som.global.exception.ErrorCode;
 import com.blog.som.global.exception.ErrorResponse;
 import com.blog.som.global.exception.custom.MemberException;
 import com.blog.som.global.exception.custom.CustomSecurityException;
+import com.blog.som.global.exception.custom.PostException;
 import com.blog.som.global.exception.custom.S3Exception;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +24,12 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler(MemberException.class)
   public ResponseEntity<ErrorResponse> handleMemberException(MemberException e) {
+    ErrorResponse errorResponse = new ErrorResponse(e.getErrorCode(), e.getErrorMessage());
+    return new ResponseEntity<>(errorResponse, e.getErrorCode().getStatus());
+  }
+
+  @ExceptionHandler(PostException.class)
+  public ResponseEntity<ErrorResponse> handlePostException(PostException e) {
     ErrorResponse errorResponse = new ErrorResponse(e.getErrorCode(), e.getErrorMessage());
     return new ResponseEntity<>(errorResponse, e.getErrorCode().getStatus());
   }

--- a/src/main/java/com/blog/som/global/redis/constant/RedisConstant.java
+++ b/src/main/java/com/blog/som/global/redis/constant/RedisConstant.java
@@ -1,0 +1,6 @@
+package com.blog.som.global.redis.constant;
+
+public class RedisConstant {
+  public static final String VIEW_PREFIX = "VIEW-";
+
+}

--- a/src/main/java/com/blog/som/global/redis/email/CacheRedisRepository.java
+++ b/src/main/java/com/blog/som/global/redis/email/CacheRedisRepository.java
@@ -3,6 +3,7 @@ package com.blog.som.global.redis.email;
 import com.blog.som.global.constant.TimeConstant;
 import com.blog.som.global.exception.ErrorCode;
 import com.blog.som.global.exception.custom.MemberException;
+import com.blog.som.global.redis.constant.RedisConstant;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,27 +14,39 @@ import org.springframework.stereotype.Repository;
 @Slf4j
 @RequiredArgsConstructor
 @Repository
-public class EmailAuthRedisRepository implements EmailAuthRepository{
+public class CacheRedisRepository implements CacheRepository {
 
   private final RedisTemplate redisTemplate;
 
 
   @Override
   public void saveEmailAuthUuid(String uuid, String email) {
-    ValueOperations<String, String> emailAuths = redisTemplate.opsForValue();
-    emailAuths.set(uuid, email, Duration.ofMinutes(TimeConstant.EMAIL_AUTH_MINUTE));
+    ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+    valueOperations.set(uuid, email, Duration.ofMinutes(TimeConstant.EMAIL_AUTH_MINUTE));
   }
 
   @Override
   public String getEmailByUuid(String uuid) {
-    ValueOperations<String, String> emailAuths = redisTemplate.opsForValue();
+    ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
 
     if(Boolean.FALSE.equals(redisTemplate.hasKey(uuid))){
       log.info("[email auth fail - email-auth key doesnt exist]");
       throw new MemberException(ErrorCode.EMAIL_AUTH_TIME_OUT);
     }
 
-    return emailAuths.get(uuid);
+    return valueOperations.get(uuid);
+  }
+
+  @Override
+  public boolean canAddView(String accessUserAgent) {
+    String key = RedisConstant.VIEW_PREFIX + accessUserAgent;
+    if(redisTemplate.hasKey(key)){
+      return false;
+    }
+    ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+    valueOperations.set(key, "view", Duration.ofMinutes(TimeConstant.ADD_VIEW_MINUTE));
+
+    return true;
   }
 
 }

--- a/src/main/java/com/blog/som/global/redis/email/CacheRepository.java
+++ b/src/main/java/com/blog/som/global/redis/email/CacheRepository.java
@@ -1,8 +1,10 @@
 package com.blog.som.global.redis.email;
 
-public interface EmailAuthRepository {
+public interface CacheRepository {
 
   void saveEmailAuthUuid(String uuid, String email);
 
   String getEmailByUuid(String uuid);
+
+  boolean canAddView(String accessUserAgent);
 }

--- a/src/test/java/com/blog/som/EntityCreator.java
+++ b/src/test/java/com/blog/som/EntityCreator.java
@@ -45,7 +45,11 @@ public class EntityCreator {
     return tagEntity;
   }
 
-  public static PostTagEntity createPostTag(Long id) {
-    return PostTagEntity.builder().build();
+  public static PostTagEntity createPostTag(Long id, PostEntity post, TagEntity tag) {
+    return PostTagEntity.builder()
+        .postTagId(id)
+        .post(post)
+        .tag(tag)
+        .build();
   }
 }

--- a/src/test/java/com/blog/som/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/blog/som/domain/member/service/MemberServiceTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.amazonaws.services.s3.model.Owner;
 import com.blog.som.EntityCreator;
 import com.blog.som.domain.member.dto.MemberDto;
 import com.blog.som.domain.member.dto.MemberEditRequest;
@@ -23,11 +22,10 @@ import com.blog.som.global.components.password.PasswordUtils;
 import com.blog.som.global.constant.ResponseConstant;
 import com.blog.som.global.exception.ErrorCode;
 import com.blog.som.global.exception.custom.MemberException;
-import com.blog.som.global.redis.email.EmailAuthRepository;
+import com.blog.som.global.redis.email.CacheRepository;
 import com.blog.som.global.s3.S3ImageService;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.time.LocalDate;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
@@ -47,7 +45,7 @@ class MemberServiceTest {
   @Mock
   private MemberRepository memberRepository;
   @Mock
-  private EmailAuthRepository emailAuthRepository;
+  private CacheRepository cacheRepository;
   @Mock
   private MailSender mailSender;
   @Mock
@@ -115,7 +113,7 @@ class MemberServiceTest {
           .build();
 
       //given
-      when(emailAuthRepository.getEmailByUuid(code))
+      when(cacheRepository.getEmailByUuid(code))
           .thenReturn(email);
       when(memberRepository.existsByEmail(email))
           .thenReturn(false);
@@ -143,7 +141,7 @@ class MemberServiceTest {
           .build();
 
       //given
-      when(emailAuthRepository.getEmailByUuid(code))
+      when(cacheRepository.getEmailByUuid(code))
           .thenReturn(email);
       when(memberRepository.existsByEmail(email))
           .thenReturn(true);
@@ -170,7 +168,7 @@ class MemberServiceTest {
           .build();
 
       //given
-      when(emailAuthRepository.getEmailByUuid(code))
+      when(cacheRepository.getEmailByUuid(code))
           .thenReturn(email);
       when(memberRepository.existsByEmail(email))
           .thenReturn(false);

--- a/src/test/java/com/blog/som/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/blog/som/domain/post/service/PostServiceTest.java
@@ -1,12 +1,17 @@
 package com.blog.som.domain.post.service;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.BDDMockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.never;
+import static org.mockito.BDDMockito.times;
+import static org.mockito.BDDMockito.verify;
+import static org.mockito.BDDMockito.when;
 
 import com.blog.som.EntityCreator;
 import com.blog.som.domain.member.entity.MemberEntity;
 import com.blog.som.domain.member.repository.MemberRepository;
+import com.blog.som.domain.post.dto.PostDeleteResponse;
 import com.blog.som.domain.post.dto.PostDto;
 import com.blog.som.domain.post.dto.PostEditRequest;
 import com.blog.som.domain.post.dto.PostWriteRequest;
@@ -25,12 +30,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -59,9 +62,9 @@ class PostServiceTest {
 
   @Nested
   @DisplayName("게시글 작성")
-  class WritePost{
+  class WritePost {
 
-    private PostWriteRequest createRequest(int id, List<String> tagList){
+    private PostWriteRequest createRequest(int id, List<String> tagList) {
       return PostWriteRequest.builder()
           .title("test-title" + id)
           .content("test-content" + id)
@@ -73,11 +76,11 @@ class PostServiceTest {
 
     @Test
     @DisplayName("성공")
-    void writePost(){
+    void writePost() {
       MemberEntity member = EntityCreator.createMember(1L);
       PostEntity post = EntityCreator.createPost(10L, member);
 
-      List<String> tagList = new ArrayList<>(Arrays.asList(TAG_1,TAG_2));
+      List<String> tagList = new ArrayList<>(Arrays.asList(TAG_1, TAG_2));
       PostWriteRequest request = createRequest(10, tagList);
 
       TagEntity tag1 = EntityCreator.createTag(100L, TAG_1, member);
@@ -104,10 +107,10 @@ class PostServiceTest {
 
     @Test
     @DisplayName("실패 : MEMBER_NOT_FOUND")
-    void writePos_MEMBER_NOT_FOUND(){
+    void writePos_MEMBER_NOT_FOUND() {
       MemberEntity member = EntityCreator.createMember(1L);
 
-      List<String> tagList = new ArrayList<>(Arrays.asList(TAG_1,TAG_2));
+      List<String> tagList = new ArrayList<>(Arrays.asList(TAG_1, TAG_2));
       PostWriteRequest request = createRequest(10, tagList);
 
       //given
@@ -124,11 +127,11 @@ class PostServiceTest {
 
   @Nested
   @DisplayName("게시글 조회")
-  class GetPost{
+  class GetPost {
 
     @Test
     @DisplayName("성공 : 조회수 증가")
-    void getPost(){
+    void getPost() {
       MemberEntity member = EntityCreator.createMember(1L);
       PostEntity post = EntityCreator.createPost(10L, member);
       TagEntity tag1 = EntityCreator.createTag(100L, TAG_1, member);
@@ -157,7 +160,7 @@ class PostServiceTest {
 
     @Test
     @DisplayName("성공 : 조회수 증가 X")
-    void getPost_never_add_vew(){
+    void getPost_never_add_vew() {
       MemberEntity member = EntityCreator.createMember(1L);
       PostEntity post = EntityCreator.createPost(10L, member);
       TagEntity tag1 = EntityCreator.createTag(100L, TAG_1, member);
@@ -186,7 +189,7 @@ class PostServiceTest {
 
     @Test
     @DisplayName("실패 : POST_NOT_FOUND")
-    void getPost_POST_NOT_FOUND(){
+    void getPost_POST_NOT_FOUND() {
       MemberEntity member = EntityCreator.createMember(1L);
       PostEntity post = EntityCreator.createPost(10L, member);
       String userAgent = "CHROME/123";
@@ -207,9 +210,9 @@ class PostServiceTest {
 
   @Nested
   @DisplayName("editPost")
-  class EditPost{
+  class EditPost {
 
-    private PostEditRequest createRequest(List<String> tags){
+    private PostEditRequest createRequest(List<String> tags) {
       return PostEditRequest.builder()
           .title("edit-test-title")
           .content("edit-test-content")
@@ -221,13 +224,11 @@ class PostServiceTest {
 
 
     /**
-     *  - 기존:TAG_1,TAG_2
-     *  - 변경:TAG_1,TAG_2
-     *  - 기존 태그와 변경된 태그가 일치할 때
+     * - 기존:TAG_1,TAG_2 - 변경:TAG_1,TAG_2 - 기존 태그와 변경된 태그가 일치할 때
      */
     @Test
     @DisplayName("성공 : 태그 그대로")
-    void editPost(){
+    void editPost() {
       MemberEntity member = EntityCreator.createMember(1L);
       PostEntity post = EntityCreator.createPost(10L, member);
 
@@ -247,7 +248,6 @@ class PostServiceTest {
       when(postTagRepository.findAllByPost(post))
           .thenReturn(postTagEntityList);
 
-
       //when
       PostDto postDto = postService.editPost(request, 10L, 1L);
 
@@ -256,7 +256,6 @@ class PostServiceTest {
       verify(postTagRepository, never()).delete(any(PostTagEntity.class));
       verify(tagRepository, never()).findByTagNameAndMember(TAG_1, member);
       verify(tagRepository, never()).findByTagNameAndMember(TAG_2, member);
-
 
       assertThat(postDto.getTags()).containsAll(list);
       assertThat(postDto.getTitle()).isEqualTo(request.getTitle());
@@ -267,14 +266,11 @@ class PostServiceTest {
 
 
     /**
-     *  - 기존:TAG_1,TAG_2
-     *  - 변경:TAG_1,TAG_3
-     *  - TAG2 count=1
-     *  - 기존에 회원은 TAG_3 갖고있지 않음
+     * - 기존:TAG_1,TAG_2 - 변경:TAG_1,TAG_3 - TAG2 count=1 - 기존에 회원은 TAG_3 갖고있지 않음
      */
     @Test
     @DisplayName("성공 : 태그 하나 변경")
-    void editPost_change_one_tag(){
+    void editPost_change_one_tag() {
       MemberEntity member = EntityCreator.createMember(1L);
       PostEntity post = EntityCreator.createPost(10L, member);
 
@@ -299,7 +295,6 @@ class PostServiceTest {
       when(tagRepository.findByTagNameAndMember(TAG_3, member)) //기존에 TAG3 없음
           .thenReturn(Optional.empty());
 
-
       //when
       PostDto postDto = postService.editPost(request, 10L, 1L);
 
@@ -319,14 +314,11 @@ class PostServiceTest {
     }
 
     /**
-     *  - 기존:TAG_1,TAG_2
-     *  - 변경:TAG_1,TAG_3
-     *  - TAG2 count=3
-     *  - 기존에 회원은 TAG_3 갖고있지 않음
+     * - 기존:TAG_1,TAG_2 - 변경:TAG_1,TAG_3 - TAG2 count=3 - 기존에 회원은 TAG_3 갖고있지 않음
      */
     @Test
     @DisplayName("성공 : 태그 하나 변경, 변경된 태그 count > 1")
-    void editPost_change_one_tag_(){
+    void editPost_change_one_tag_() {
       MemberEntity member = EntityCreator.createMember(1L);
       PostEntity post = EntityCreator.createPost(10L, member);
 
@@ -352,7 +344,6 @@ class PostServiceTest {
       when(tagRepository.findByTagNameAndMember(TAG_3, member)) //기존에 TAG3 없음
           .thenReturn(Optional.empty());
 
-
       //when
       PostDto postDto = postService.editPost(request, 10L, 1L);
 
@@ -372,7 +363,7 @@ class PostServiceTest {
 
     @Test
     @DisplayName("실패 : POST_NOT_FOUND")
-    void editPost_POST_NOT_FOUND(){
+    void editPost_POST_NOT_FOUND() {
       MemberEntity member = EntityCreator.createMember(1L);
       PostEntity post = EntityCreator.createPost(10L, member);
       List<String> list = new ArrayList<>(Arrays.asList(TAG_1, TAG_3));
@@ -391,7 +382,7 @@ class PostServiceTest {
 
     @Test
     @DisplayName("실패 : POST_EDIT_NO_AUTHORITY")
-    void editPost_POST_EDIT_NO_AUTHORITY(){
+    void editPost_POST_EDIT_NO_AUTHORITY() {
       MemberEntity member = EntityCreator.createMember(1L);
       PostEntity post = EntityCreator.createPost(10L, member);
       List<String> list = new ArrayList<>(Arrays.asList(TAG_1, TAG_3));
@@ -406,6 +397,104 @@ class PostServiceTest {
           assertThrows(PostException.class, () -> postService.editPost(request, 10L, 2L));
       assertThat(postException.getErrorCode()).isEqualTo(ErrorCode.POST_EDIT_NO_AUTHORITY);
 
+    }
+  }
+
+  @Nested
+  @DisplayName("게시글 삭제")
+  class DeletePost {
+
+    @Test
+    @DisplayName("성공 - tag.count=1")
+    void deletePost() {
+      MemberEntity member = EntityCreator.createMember(1L);
+      PostEntity post = EntityCreator.createPost(10L, member);
+
+      TagEntity tag1 = EntityCreator.createTag(101L, TAG_1, member);
+      tag1.setCount(1);
+      PostTagEntity postTag1 = EntityCreator.createPostTag(1001L, post, tag1);
+
+      List<PostTagEntity> postTagEntityList = new ArrayList<>(Arrays.asList(postTag1));
+
+      //given
+      when(postRepository.findById(10L))
+          .thenReturn(Optional.of(post));
+      when(postTagRepository.findAllByPost(post))
+          .thenReturn(postTagEntityList);
+
+      //when
+      PostDeleteResponse response = postService.deletePost(10L, 1L);
+
+      //then
+      verify(postTagRepository, times(1)).delete(postTag1);
+      verify(tagRepository, times(1)).delete(tag1);
+      verify(postRepository, times(1)).delete(post);
+
+      assertThat(response.getPostId()).isEqualTo(10L);
+      assertThat(response.getPostTitle()).isEqualTo(post.getTitle());
+    }
+
+    @Test
+    @DisplayName("성공 - tag.count > 1")
+    void deletePost_tag_count_3() {
+      MemberEntity member = EntityCreator.createMember(1L);
+      PostEntity post = EntityCreator.createPost(10L, member);
+
+      TagEntity tag1 = EntityCreator.createTag(101L, TAG_1, member);
+      tag1.setCount(3);
+      PostTagEntity postTag1 = EntityCreator.createPostTag(1001L, post, tag1);
+
+      List<PostTagEntity> postTagEntityList = new ArrayList<>(Arrays.asList(postTag1));
+
+      //given
+      when(postRepository.findById(10L))
+          .thenReturn(Optional.of(post));
+      when(postTagRepository.findAllByPost(post))
+          .thenReturn(postTagEntityList);
+
+      //when
+      PostDeleteResponse response = postService.deletePost(10L, 1L);
+
+      //then
+      verify(postTagRepository, times(1)).delete(postTag1);
+      verify(tagRepository, never()).delete(tag1);
+      verify(tagRepository, times(1)).save(tag1);
+      verify(postRepository, times(1)).delete(post);
+
+      assertThat(response.getPostId()).isEqualTo(10L);
+      assertThat(response.getPostTitle()).isEqualTo(post.getTitle());
+    }
+
+    @Test
+    @DisplayName("실패 : POST_NOT_FOUND")
+    void deletePost_POST_POST_NOT_FOUND() {
+      MemberEntity member = EntityCreator.createMember(1L);
+      PostEntity post = EntityCreator.createPost(10L, member);
+
+      //given
+      when(postRepository.findById(11L))
+          .thenReturn(Optional.empty());
+
+      //when
+      PostException postException =
+          assertThrows(PostException.class, () -> postService.deletePost(11L, 1L));
+      assertThat(postException.getErrorCode()).isEqualTo(ErrorCode.POST_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("실패 : POST_DELETE_NO_AUTHORITY")
+    void deletePost_POST_DELETE_NO_AUTHORITY() {
+      MemberEntity member = EntityCreator.createMember(1L);
+      PostEntity post = EntityCreator.createPost(10L, member);
+
+      //given
+      when(postRepository.findById(10L))
+          .thenReturn(Optional.of(post));
+
+      //when
+      PostException postException =
+          assertThrows(PostException.class, () -> postService.deletePost(10L, 2L));
+      assertThat(postException.getErrorCode()).isEqualTo(ErrorCode.POST_DELETE_NO_AUTHORITY);
     }
 
   }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요.  -->
### [게시글 조회]
- `PostTagEntity`를 `postTagRepository.findAllByPost()`로 모두 찾아서 List<String>을 반환받아 PostDto에 담아서 반환한다.

### [게시글 조회 수 증가]
- 게시글 조회 수는 한 사람이 30분마다 1번씩 증가시킬 수 있다.
- "한 사람"을 식별하는 기준은 클라이언트로부터 `Custom-Access-User` Header로 User-Agent 문자열을 받아서 Redis의 Key로 사용한다.
- Key에는 Prefix로 `VIEW-`를 사용한다.
- `CacheRepository.canAddView()`를 호출하여 boolean으로 addView를 할 수 있는지 확인한다.
    - true일 경우 : redis에 `VIEW-{User-Agent}`를 넣고, 게시글의 `views`를 증가시킨다.

### [게시글 수정]
- 우선 로그인 유저에게 수정 권한이 있는지 검증한다.
- `post`관련 필드 먼저 수정한다.
- Request로 들어온 `tags`(태그 리스트)를 기존 Post의 태그 리스트와 비교한다.
1. 삭제된 태그의 경우 먼저 처리한다.
    - DB에도 있고, request에도 있는 경우 : 해당 태그에 대한 엔티티 변경은 일어나지 않는다.
    - DB에는 있지만, request에는 없는 경우 : 기존 `PostTagEntity`는 삭제하고, `TagEntity`의 count를 하나 뺀다.
    - 만약 `TagEntity.count=1`인 경우 `TagEntity`도 삭제한다.
2. 추가 된 태그의 경우를 처리한다. (`editRequestTags`에 남아있는 tag List)
     - 기존 DB에 `tagName`이 존재할 때 : `TagEntity`의 count를 하나 추가한다.
     - 기존 DB에 `tagName`이 없을 때 : `TagEntity`를 `count=1`로 생성한다.

### [게시글 삭제]
- 우선 로그인 유저에게 삭제 권한이 있는지 검증한다.
- 해당 게시글에 포함된 `PostTag` list를 하나씩 돌며 모두 삭제한다.
- 삭제 시 각각 `PostTag`를 삭제하고, `PostTag`에 연결된 `Tag`의 count에 따라 처리한다.
   - count <= 1 : `TagEntity` 삭제
   - count > 1 : `TagEntity` -> `count -= 1`

---

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 

