### PR TITLE
Fix : SecurityFilter에 accessToken Blacklist 확인하는 로직 추가, reissue 로직 수정

### DIFF
--- a/src/main/java/com/blog/som/domain/member/controller/AuthController.java
+++ b/src/main/java/com/blog/som/domain/member/controller/AuthController.java
@@ -12,6 +12,7 @@ import io.swagger.annotations.ApiOperation;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -41,6 +42,7 @@ public class AuthController {
   }
 
   @ApiOperation(value = "로그아웃", notes = "accessToken blacklist 처리")
+  @PreAuthorize("hasAnyRole('ROLE_USER')")
   @PostMapping("/logout")
   public ResponseEntity<MemberLogoutResponse> logout(
       @AuthenticationPrincipal LoginMember loginMember,
@@ -55,6 +57,7 @@ public class AuthController {
   }
 
   @ApiOperation(value = "토큰 재발급", notes = "[RefreshToken] header에 Bearer {refreshToken}을 받으면 AT와 RT를 모두 재발급")
+  @PreAuthorize("hasAnyRole('ROLE_USER')")
   @GetMapping("/reissue")
   public ResponseEntity<MemberLogin.Response> reissueToken(
       @AuthenticationPrincipal LoginMember loginMember,

--- a/src/main/java/com/blog/som/domain/member/controller/AuthController.java
+++ b/src/main/java/com/blog/som/domain/member/controller/AuthController.java
@@ -57,14 +57,13 @@ public class AuthController {
   }
 
   @ApiOperation(value = "토큰 재발급", notes = "[RefreshToken] header에 Bearer {refreshToken}을 받으면 AT와 RT를 모두 재발급")
-  @PreAuthorize("hasAnyRole('ROLE_USER')")
   @GetMapping("/reissue")
   public ResponseEntity<MemberLogin.Response> reissueToken(
-      @AuthenticationPrincipal LoginMember loginMember,
       @RequestHeader("RefreshToken") String refreshToken,
       HttpServletResponse httpServletResponse
       ){
-    Response response = authService.reissueTokens(loginMember.getEmail(), loginMember.getRole(), refreshToken);
+    Response response = authService
+        .reissueTokens(refreshToken);
     cookieService.setCookieForLogin(httpServletResponse, response.getTokenResponse().getAccessToken());
 
     return ResponseEntity.ok(response);

--- a/src/main/java/com/blog/som/domain/member/controller/MemberController.java
+++ b/src/main/java/com/blog/som/domain/member/controller/MemberController.java
@@ -12,6 +12,7 @@ import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -46,6 +47,7 @@ public class MemberController {
   }
 
   @ApiOperation(value = "회원 정보 수정", notes = "비밀번호 제외")
+  @PreAuthorize("hasAnyRole('ROLE_USER')")
   @PutMapping("/member")
   public ResponseEntity<MemberDto> editMemberInfo(
       @RequestBody MemberEditRequest request,
@@ -56,6 +58,7 @@ public class MemberController {
   }
 
   @ApiOperation(value = "회원 비밀번호 수정")
+  @PreAuthorize("hasAnyRole('ROLE_USER')")
   @PutMapping("/member/edit-password")
   public ResponseEntity<MemberPasswordEdit.Response> editMemberPassword(
       @RequestBody MemberPasswordEdit.Request request,
@@ -66,6 +69,7 @@ public class MemberController {
   }
 
   @ApiOperation(value = "프로필 사진 변경(등록)", notes = "기존의 것이 있으면 덮어쓴다.")
+  @PreAuthorize("hasAnyRole('ROLE_USER')")
   @PutMapping("/member/profile-image")
   public ResponseEntity<MemberDto> editProfileImage(@RequestPart(required = false) MultipartFile profileImage,
       @AuthenticationPrincipal LoginMember loginMember) {
@@ -74,6 +78,7 @@ public class MemberController {
   }
 
   @ApiOperation(value = "프로필 사진 삭제", notes = "프로필 사진을 null로 수정")
+  @PreAuthorize("hasAnyRole('ROLE_USER')")
   @DeleteMapping("/member/profile-image/remove")
   public ResponseEntity<MemberDto> deleteProfileImage(@AuthenticationPrincipal LoginMember loginMember) {
     MemberDto memberDto = memberService.deleteProfileImage(loginMember.getMemberId());

--- a/src/main/java/com/blog/som/domain/member/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/blog/som/domain/member/security/filter/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package com.blog.som.domain.member.security.filter;
 
 import com.blog.som.domain.member.security.token.JwtTokenService;
+import com.blog.som.global.redis.token.TokenRepository;
 import java.io.IOException;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -25,13 +26,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   public static final String TOKEN_HEADER = "Authorization";
 
   private final JwtTokenService jwtTokenService;
+  private final TokenRepository tokenRepository;
 
   @Override
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
       FilterChain filterChain) throws ServletException, IOException {
     String token = jwtTokenService.resolveTokenFromRequest(request.getHeader(TOKEN_HEADER));
 
-    if (StringUtils.hasText(token) && jwtTokenService.validateToken(token)) {
+    if (StringUtils.hasText(token) && jwtTokenService.validateToken(token)
+    && !tokenRepository.isAccessTokenBlacklist(token)) {
       //토큰 유효성 검증 성공
       Authentication auth = jwtTokenService.getAuthentication(token);
       SecurityContextHolder.getContext().setAuthentication(auth);

--- a/src/main/java/com/blog/som/domain/member/security/service/AuthService.java
+++ b/src/main/java/com/blog/som/domain/member/security/service/AuthService.java
@@ -51,8 +51,9 @@ public class AuthService {
     return new MemberLogoutResponse(email, result);
   }
 
-  public MemberLogin.Response reissueTokens(String email, Role role, String bearerRefreshToken) {
+  public MemberLogin.Response reissueTokens(String bearerRefreshToken) {
     String refreshToken = jwtTokenService.resolveTokenFromRequest(bearerRefreshToken);
+    String email = jwtTokenService.getUsernameByToken(refreshToken);
 
     MemberEntity member = memberRepository.findByEmail(email)
         .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
@@ -60,7 +61,7 @@ public class AuthService {
     //redis에서 refreshToken 확인
     tokenRepository.checkRefreshToken(email, refreshToken);
     // 토큰 새로 생성
-    TokenResponse tokenResponse = jwtTokenService.generateTokenResponse(email, role);
+    TokenResponse tokenResponse = jwtTokenService.generateTokenResponse(email, member.getRole());
     // 새로 생성된 refreshToken 저장
     tokenRepository.saveRefreshToken(email, tokenResponse.getRefreshToken());
 

--- a/src/main/java/com/blog/som/domain/member/security/token/JwtTokenService.java
+++ b/src/main/java/com/blog/som/domain/member/security/token/JwtTokenService.java
@@ -88,6 +88,10 @@ public class JwtTokenService {
     return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
   }
 
+  public String getUsernameByToken(String token){
+    return this.parseClaims(token).getSubject();
+  }
+
   /**
    * 토큰이 유효한지 확인
    */

--- a/src/main/java/com/blog/som/domain/post/controller/PostController.java
+++ b/src/main/java/com/blog/som/domain/post/controller/PostController.java
@@ -12,6 +12,7 @@ import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -31,6 +32,7 @@ public class PostController {
   private final PostService postService;
 
   @ApiOperation("게시글 작성")
+  @PreAuthorize("hasAnyRole('ROLE_USER')")
   @PostMapping("/post")
   public ResponseEntity<PostDto> writePost(@RequestBody PostWriteRequest request,
       @AuthenticationPrincipal LoginMember loginMember) {
@@ -51,6 +53,7 @@ public class PostController {
   }
 
   @ApiOperation("게시글 수정")
+  @PreAuthorize("hasAnyRole('ROLE_USER')")
   @PutMapping("/post/{postId}")
   public ResponseEntity<PostDto> editPost(@PathVariable Long postId,
       @RequestBody PostEditRequest postEditRequest,
@@ -62,6 +65,7 @@ public class PostController {
   }
 
   @ApiOperation("게시글 삭제")
+  @PreAuthorize("hasAnyRole('ROLE_USER')")
   @DeleteMapping("/post/{postId}")
   public ResponseEntity<PostDeleteResponse> deletePost(@PathVariable Long postId,
       @AuthenticationPrincipal LoginMember loginMember){

--- a/src/main/java/com/blog/som/global/redis/token/RedisTokenRepository.java
+++ b/src/main/java/com/blog/som/global/redis/token/RedisTokenRepository.java
@@ -39,6 +39,11 @@ public class RedisTokenRepository implements TokenRepository {
   }
 
   @Override
+  public boolean isAccessTokenBlacklist(String accessToken) {
+    return Boolean.TRUE.equals(redisTemplate.hasKey(TokenConstant.ACCESS_TOKEN_BLACKLIST_PREFIX + accessToken));
+  }
+
+  @Override
   public boolean deleteRefreshToken(String email) {
     return Boolean.TRUE.equals(redisTemplate.delete(TokenConstant.REFRESH_TOKEN_EMAIL_KEY_PREFIX + email));
   }

--- a/src/main/java/com/blog/som/global/redis/token/TokenRepository.java
+++ b/src/main/java/com/blog/som/global/redis/token/TokenRepository.java
@@ -6,6 +6,8 @@ public interface TokenRepository {
 
   void addBlacklistAccessToken(String accessToken, String email);
 
+  boolean isAccessTokenBlacklist(String accessToken);
+
   boolean deleteRefreshToken(String email);
 
   boolean checkRefreshToken(String email, String refreshToken);

--- a/src/test/java/com/blog/som/domain/member/security/service/AuthServiceTest.java
+++ b/src/test/java/com/blog/som/domain/member/security/service/AuthServiceTest.java
@@ -164,13 +164,16 @@ class AuthServiceTest {
       //given
       when(jwtTokenService.resolveTokenFromRequest(bearerRefreshToken))
           .thenReturn(refreshToken);
+      when(jwtTokenService.getUsernameByToken(refreshToken))
+          .thenReturn(member.getEmail());
       when(memberRepository.findByEmail(member.getEmail()))
           .thenReturn(Optional.of(member));
       when(jwtTokenService.generateTokenResponse(member.getEmail(), member.getRole()))
           .thenReturn(tokenResponse);
 
+
       //when
-      Response response = authService.reissueTokens(member.getEmail(), member.getRole(), bearerRefreshToken);
+      Response response = authService.reissueTokens(bearerRefreshToken);
 
       //then
       verify(tokenRepository, times(1)).checkRefreshToken(member.getEmail(), refreshToken);
@@ -195,6 +198,8 @@ class AuthServiceTest {
       //given
       when(jwtTokenService.resolveTokenFromRequest(bearerRefreshToken))
           .thenReturn(refreshToken);
+      when(jwtTokenService.getUsernameByToken(refreshToken))
+          .thenReturn(member.getEmail());
       when(memberRepository.findByEmail(member.getEmail()))
           .thenReturn(Optional.empty());
 
@@ -202,7 +207,7 @@ class AuthServiceTest {
       //then
       MemberException memberException =
           assertThrows(MemberException.class,
-          () -> authService.reissueTokens(member.getEmail(), member.getRole(), bearerRefreshToken));
+          () -> authService.reissueTokens(bearerRefreshToken));
       assertThat(memberException.getErrorCode()).isEqualTo(ErrorCode.MEMBER_NOT_FOUND);
     }
 


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요.  -->
### [SecurityFilter]
- accessToken Blacklist에 포함된 accessToken인지 확인하는 로직 추가

### [reissue 변경]
- 기존에는 accessToken을 파싱해서 `LoginMember`가 있어야만 `reissue` 요청을 할 수 있던 오류가 있었음.
- refreshToken 만으로 재발급 할 수 있도록 수정

---

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 

