### PR TITLE
Feat : 블로그 메인 페이지 조회 API

### DIFF
--- a/src/main/java/com/blog/som/domain/blog/controller/BlogController.java
+++ b/src/main/java/com/blog/som/domain/blog/controller/BlogController.java
@@ -1,12 +1,19 @@
 package com.blog.som.domain.blog.controller;
 
 
+import com.blog.som.domain.blog.dto.BlogMemberDto;
+import com.blog.som.domain.blog.dto.BlogPostList;
+import com.blog.som.domain.blog.service.BlogService;
+import com.blog.som.global.exception.ErrorCode;
+import com.blog.som.global.exception.custom.BlogException;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Api(tags = "블로그(blog)")
@@ -14,11 +21,44 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class BlogController {
 
-  @ApiOperation("Blog main")
-  @GetMapping("/{blogName}")
-  public ResponseEntity<?> blogMain(@PathVariable String blogName){
+  private final BlogService blogService;
 
-      return ResponseEntity.ok(null);
+  @ApiOperation("블로그 회원 정보 조회")
+  @GetMapping("/blog/{accountName}/member")
+  public ResponseEntity<BlogMemberDto> blogMember(@PathVariable String accountName){
+
+    BlogMemberDto blogMember = blogService.getBlogMember(accountName);
+
+    return ResponseEntity.ok(blogMember);
+  }
+
+  @ApiOperation("블로그 게시글 list 조회")
+  @GetMapping("/blog/{accountName}/posts")
+  public ResponseEntity<BlogPostList> blogPosts(@PathVariable String accountName,
+      @RequestParam(value = "sort", required = false, defaultValue = "latest") String sort,
+      @RequestParam(value = "tag", required = false, defaultValue = "") String tagName,
+      @RequestParam(value = "q", required = false, defaultValue = "")String query,
+      @RequestParam(value = "p",required = false, defaultValue = "1") int page){
+    //두가지 모두 query로 들어올 순 없음
+    if (StringUtils.hasText(tagName) && StringUtils.hasText(query)) {
+      throw new BlogException(ErrorCode.BLOG_POSTS_INVALID_QUERY);
+    }
+    //hot
+    if(sort.equals("hot")){
+      return ResponseEntity.ok(blogService.getBlogPostListBySortType(accountName, sort, page));
+    }
+    //tag 검색
+    if(StringUtils.hasText(tagName)){
+      return ResponseEntity.ok(blogService.getBlogPostListByTag(accountName, tagName, page));
+    }
+
+    //query 검색
+    if(StringUtils.hasText(query)){
+      return ResponseEntity.ok(blogService.getBlogPostListByQuery(accountName, query, page));
+    }
+
+    //전체 검색
+    return ResponseEntity.ok(blogService.getBlogPostListBySortType(accountName, sort, page));
   }
 
 }

--- a/src/main/java/com/blog/som/domain/blog/dto/BlogMemberDto.java
+++ b/src/main/java/com/blog/som/domain/blog/dto/BlogMemberDto.java
@@ -1,0 +1,34 @@
+package com.blog.som.domain.blog.dto;
+
+import com.blog.som.domain.member.entity.MemberEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class BlogMemberDto {
+  private String blogName;
+  private String profileImage;
+  private String nickname;
+  private String introduction;
+
+  private int followerCount;
+  private int followCount;
+
+  public static BlogMemberDto fromEntity(MemberEntity member, int followCount, int followerCount){
+    return BlogMemberDto.builder()
+        .blogName(member.getBlogName())
+        .profileImage(member.getProfileImage())
+        .nickname(member.getNickname())
+        .introduction(member.getIntroduction())
+        .followerCount(followerCount)
+        .followCount(followCount)
+        .build();
+  }
+}

--- a/src/main/java/com/blog/som/domain/blog/dto/BlogPostDto.java
+++ b/src/main/java/com/blog/som/domain/blog/dto/BlogPostDto.java
@@ -1,0 +1,57 @@
+package com.blog.som.domain.blog.dto;
+
+import com.blog.som.domain.post.entity.PostEntity;
+import java.time.LocalDateTime;
+import java.util.List;
+import javax.persistence.EntityListeners;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class BlogPostDto {
+
+  private Long postId;
+
+  private Long memberId;
+
+  private String accountName;
+
+  private String title;
+
+  private String thumbnail;
+
+  private String introduction;
+
+  private int likes;
+
+  private int views;
+
+  private LocalDateTime registeredAt;
+
+  private List<String> tags;
+
+  public static BlogPostDto fromEntity(PostEntity post, List<String> tagList) {
+    return BlogPostDto.builder()
+        .postId(post.getPostId())
+        .memberId(post.getMember().getMemberId())
+        .accountName(post.getMember().getAccountName())
+        .title(post.getTitle())
+        .thumbnail(post.getThumbnail())
+        .introduction(post.getIntroduction())
+        .likes(post.getLikes())
+        .views(post.getViews())
+        .registeredAt(post.getRegisteredAt())
+        .tags(tagList)
+        .build();
+  }
+}
+

--- a/src/main/java/com/blog/som/domain/blog/dto/BlogPostList.java
+++ b/src/main/java/com/blog/som/domain/blog/dto/BlogPostList.java
@@ -1,0 +1,25 @@
+package com.blog.som.domain.blog.dto;
+
+import com.blog.som.global.dto.PageDto;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Builder
+public class BlogPostList {
+
+  private PageDto pageDto;
+  private List<BlogPostDto> postList;
+
+  public BlogPostList (PageDto pageDto, List<BlogPostDto> postList){
+    this.pageDto = pageDto;
+    this.postList = postList;
+  }
+}

--- a/src/main/java/com/blog/som/domain/blog/service/BlogService.java
+++ b/src/main/java/com/blog/som/domain/blog/service/BlogService.java
@@ -5,8 +5,28 @@ import com.blog.som.domain.blog.dto.BlogMemberDto;
 import com.blog.som.domain.blog.dto.BlogPostList;
 
 public interface BlogService {
+
+  /**
+   * 블로그 회원 정보 조회
+   */
   BlogMemberDto getBlogMember(String accountName);
+
+  /**
+   * 정렬 방식에 따른 postList 조회
+   * - sort=latest(default) : 최신 순
+   * - sort=hot : 조회수 순
+   */
   BlogPostList getBlogPostListBySortType(String accountName, String sort, int page);
+
+  /**
+   * tagName 태그를 가진 postList 조회
+   * - 정렬 : 최신 순
+   */
   BlogPostList getBlogPostListByTag(String accountName, String tagName, int page);
+
+  /**
+   * title 또는 introduction에 "query"를 포함한 postList 조회
+   * - 정렬 : 최신 순
+   */
   BlogPostList getBlogPostListByQuery(String accountName, String query, int page);
 }

--- a/src/main/java/com/blog/som/domain/blog/service/BlogService.java
+++ b/src/main/java/com/blog/som/domain/blog/service/BlogService.java
@@ -1,6 +1,12 @@
 package com.blog.som.domain.blog.service;
 
 
-public interface BlogService {
+import com.blog.som.domain.blog.dto.BlogMemberDto;
+import com.blog.som.domain.blog.dto.BlogPostList;
 
+public interface BlogService {
+  BlogMemberDto getBlogMember(String accountName);
+  BlogPostList getBlogPostListBySortType(String accountName, String sort, int page);
+  BlogPostList getBlogPostListByTag(String accountName, String tagName, int page);
+  BlogPostList getBlogPostListByQuery(String accountName, String query, int page);
 }

--- a/src/main/java/com/blog/som/domain/blog/service/BlogServiceImpl.java
+++ b/src/main/java/com/blog/som/domain/blog/service/BlogServiceImpl.java
@@ -1,8 +1,114 @@
 package com.blog.som.domain.blog.service;
 
+import com.blog.som.domain.blog.dto.BlogMemberDto;
+import com.blog.som.domain.blog.dto.BlogPostDto;
+import com.blog.som.domain.blog.dto.BlogPostList;
+import com.blog.som.domain.member.entity.MemberEntity;
+import com.blog.som.domain.member.repository.MemberRepository;
+import com.blog.som.domain.post.entity.PostEntity;
+import com.blog.som.domain.post.repository.PostRepository;
+import com.blog.som.domain.tag.entity.PostTagEntity;
+import com.blog.som.domain.tag.entity.TagEntity;
+import com.blog.som.domain.tag.repository.PostTagRepository;
+import com.blog.som.domain.tag.repository.TagRepository;
+import com.blog.som.global.constant.NumberConstant;
+import com.blog.som.global.dto.PageDto;
+import com.blog.som.global.exception.ErrorCode;
+import com.blog.som.global.exception.custom.BlogException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
+@Slf4j
+@RequiredArgsConstructor
 @Service
 public class BlogServiceImpl implements BlogService {
 
+  private final MemberRepository memberRepository;
+  private final PostRepository postRepository;
+  private final TagRepository tagRepository;
+  private final PostTagRepository postTagRepository;
+
+  @Override
+  public BlogMemberDto getBlogMember(String accountName) {
+    MemberEntity member = memberRepository.findByAccountName(accountName)
+        .orElseThrow(() -> new BlogException(ErrorCode.BLOG_NOT_FOUND));
+
+    return BlogMemberDto.fromEntity(member, 0, 0);
+  }
+
+  @Override
+  public BlogPostList getBlogPostListBySortType(String accountName, String sort, int page) {
+    MemberEntity member = memberRepository.findByAccountName(accountName)
+        .orElseThrow(() -> new BlogException(ErrorCode.BLOG_NOT_FOUND));
+
+    String sortBy = "registeredAt";
+    if(sort.equals("hot")){
+      sortBy = "views";
+    }
+
+    Page<PostEntity> posts =
+        postRepository.findByMember(member,
+            PageRequest.of(page - 1, NumberConstant.DEFAULT_PAGE_SIZE, Sort.by(sortBy).descending()));
+
+    List<BlogPostDto> blogPostList =
+        posts.getContent().stream()
+            .map(this::getBlogPostDtoFromPostEntity)
+            .toList();
+
+    return new BlogPostList(PageDto.fromPostEntityPage(posts), blogPostList);
+  }
+
+  @Override
+  public BlogPostList getBlogPostListByTag(String accountName, String tagName, int page) {
+    MemberEntity member = memberRepository.findByAccountName(accountName)
+        .orElseThrow(() -> new BlogException(ErrorCode.BLOG_NOT_FOUND));
+
+    TagEntity tag = tagRepository.findByTagNameAndMember(tagName, member)
+        .orElseThrow(() -> new BlogException(ErrorCode.TAG_NOT_FOUND));
+
+    PageRequest pageRequest =
+        PageRequest.of(page - 1, NumberConstant.DEFAULT_PAGE_SIZE,
+            Sort.by("postCreatedTime").descending());
+
+    Page<PostTagEntity> postTags = postTagRepository.findByMemberAndTag(member, tag, pageRequest);
+
+    List<PostEntity> posts = postTags.getContent().stream().map(PostTagEntity::getPost).toList();
+
+    List<BlogPostDto> blogPostList = posts.stream().map(this::getBlogPostDtoFromPostEntity).toList();
+
+
+    return new BlogPostList(PageDto.fromPostTagEntityEntityPage(postTags), blogPostList);
+  }
+
+  @Override
+  public BlogPostList getBlogPostListByQuery(String accountName, String query, int page) {
+    MemberEntity member = memberRepository.findByAccountName(accountName)
+        .orElseThrow(() -> new BlogException(ErrorCode.BLOG_NOT_FOUND));
+
+    PageRequest pageRequest =
+        PageRequest.of(page - 1, NumberConstant.DEFAULT_PAGE_SIZE,
+            Sort.by("registeredAt").descending());
+
+    Page<PostEntity> posts =
+        postRepository.findByTitleContainingOrIntroductionContaining(query, query, pageRequest);
+
+    List<BlogPostDto> blogPostList = posts.getContent().stream().map(this::getBlogPostDtoFromPostEntity).toList();
+
+    return new BlogPostList(PageDto.fromPostEntityPage(posts), blogPostList);
+  }
+
+
+  private BlogPostDto getBlogPostDtoFromPostEntity(PostEntity postEntity) {
+    List<String> tagList =
+        postTagRepository.findAllByPost(postEntity)
+            .stream()
+            .map(pt -> pt.getTag().getTagName())
+            .toList();
+    return BlogPostDto.fromEntity(postEntity, tagList);
+  }
 }

--- a/src/main/java/com/blog/som/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/blog/som/domain/member/repository/MemberRepository.java
@@ -13,4 +13,6 @@ public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
   boolean existsByAccountName(String accountName);
 
   Optional<MemberEntity> findByEmail(String email);
+
+  Optional<MemberEntity> findByAccountName(String accountName);
 }

--- a/src/main/java/com/blog/som/domain/member/security/config/SecurityConfig.java
+++ b/src/main/java/com/blog/som/domain/member/security/config/SecurityConfig.java
@@ -62,12 +62,12 @@ public class SecurityConfig {
 
     http
         .authorizeRequests()
-        .antMatchers(PERMIT_ALL_URL)
-        .permitAll()
         .antMatchers("/admin/**")
         .hasAuthority("ROLE_ADMIN")
         .antMatchers(PERMIT_ONLY_MEMBER)
-        .hasAuthority("ROLE_USER");
+        .hasAuthority("ROLE_USER")
+        .antMatchers("/**")
+        .permitAll();
 
     http
         .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/blog/som/domain/member/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/blog/som/domain/member/security/filter/JwtAuthenticationFilter.java
@@ -40,6 +40,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
       SecurityContextHolder.getContext().setAuthentication(auth);
     } else {
       log.info("토큰 유효성 검증 실패 !!!");
+      Authentication auth = jwtTokenService.getAnonymousAuthentication();
+      SecurityContextHolder.getContext().setAuthentication(auth);
     }
     filterChain.doFilter(request, response);
   }

--- a/src/main/java/com/blog/som/domain/member/security/filter/JwtExceptionFilter.java
+++ b/src/main/java/com/blog/som/domain/member/security/filter/JwtExceptionFilter.java
@@ -34,8 +34,8 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
       String message = e.getMessage();
       if (message.equals(ErrorCode.JWT_TOKEN_WRONG_TYPE.getDescription())) {
         setResponse(response, ErrorCode.JWT_TOKEN_WRONG_TYPE);
-      } else if (message.equals(ErrorCode.TOKEN_TIME_OUT.getDescription())) {
-        setResponse(response, ErrorCode.TOKEN_TIME_OUT);
+      } else if (message.equals(ErrorCode.JWT_TOKEN_MALFORMED.getDescription())) {
+        setResponse(response, ErrorCode.JWT_TOKEN_MALFORMED);
       }
     }
   }

--- a/src/main/java/com/blog/som/domain/member/security/userdetails/LoginMember.java
+++ b/src/main/java/com/blog/som/domain/member/security/userdetails/LoginMember.java
@@ -6,7 +6,6 @@ import com.blog.som.domain.member.type.Role;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import lombok.Data;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -34,6 +33,13 @@ public class LoginMember implements UserDetails {
     this.email = member.getEmail();
     this.password = member.getPassword();
     this.role = member.getRole();
+  }
+
+  public LoginMember(Role role){
+    this.memberId = 0L;
+    this.email = "expired token";
+    this.password = "expired token";
+    this.role = Role.UNAUTH;
   }
 
   @Override

--- a/src/main/java/com/blog/som/domain/member/service/MemberService.java
+++ b/src/main/java/com/blog/som/domain/member/service/MemberService.java
@@ -1,6 +1,5 @@
 package com.blog.som.domain.member.service;
 
-import com.blog.som.domain.member.dto.EmailAuthResult;
 import com.blog.som.domain.member.dto.MemberDto;
 import com.blog.som.domain.member.dto.MemberEditRequest;
 import com.blog.som.domain.member.dto.MemberPasswordEdit;
@@ -9,15 +8,33 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface MemberService {
 
+  /**
+   * 회원 가입 이전에 이메일 중복 확인 결과 반환, 중복이 아닐 시 회원 가입 메일 발송
+   */
   MemberRegister.EmailDuplicateResponse emailDuplicateCheckAndStartRegister(String email);
 
+  /**
+   * 회원 가입
+   */
   MemberDto registerMember(MemberRegister.Request request, String code);
 
+  /**
+   * 회원 정보 수정
+   */
   MemberDto editMemberInfo(Long memberId, MemberEditRequest request);
 
+  /**
+   * 비밀번호 수정
+   */
   MemberPasswordEdit.Response editMemberPassword(Long memberId, MemberPasswordEdit.Request request);
 
+  /**
+   * 프로필 사진 등록 또는 수정
+   */
   MemberDto updateProfileImage(Long memberId, MultipartFile profileImage);
 
+  /**
+   * 프로필 사진 삭제
+   */
   MemberDto deleteProfileImage(Long memberId);
 }

--- a/src/main/java/com/blog/som/domain/member/type/Role.java
+++ b/src/main/java/com/blog/som/domain/member/type/Role.java
@@ -2,6 +2,7 @@ package com.blog.som.domain.member.type;
 
 
 public enum Role {
+  UNAUTH,
   USER,
   ADMIN;
 }

--- a/src/main/java/com/blog/som/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/blog/som/domain/post/repository/PostRepository.java
@@ -1,10 +1,17 @@
 package com.blog.som.domain.post.repository;
 
+import com.blog.som.domain.member.entity.MemberEntity;
 import com.blog.som.domain.post.entity.PostEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostRepository extends JpaRepository<PostEntity, Long> {
 
+  Page<PostEntity> findByMember(MemberEntity member, Pageable pageable);
+
+  Page<PostEntity> findByTitleContainingOrIntroductionContaining(
+      String title, String introduction, Pageable pageable);
 }

--- a/src/main/java/com/blog/som/domain/post/service/PostService.java
+++ b/src/main/java/com/blog/som/domain/post/service/PostService.java
@@ -8,12 +8,24 @@ import com.blog.som.domain.post.dto.PostWriteRequest;
 
 public interface PostService {
 
+  /**
+   * 게시글 작성
+   */
   PostDto writePost(PostWriteRequest request, Long memberId);
 
+  /**
+   * 게시글 조회
+   */
   PostDto getPost(Long postId, String accessUserAgent);
 
+  /**
+   * 게시글 수정
+   */
   PostDto editPost(PostEditRequest postEditRequest, Long postId, Long loginMemberId);
 
+  /**
+   * 게시글 삭제
+   */
   PostDeleteResponse deletePost(Long postId, Long loginMemberId);
 
 }

--- a/src/main/java/com/blog/som/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/blog/som/domain/post/service/PostServiceImpl.java
@@ -128,7 +128,7 @@ public class PostServiceImpl implements PostService {
       }
 
       tagRepository.save(tagEntity);
-      postTagRepository.save(new PostTagEntity(post, tagEntity));
+      postTagRepository.save(new PostTagEntity(post, tagEntity, member));
     }
   }
 

--- a/src/main/java/com/blog/som/domain/tag/entity/PostTagEntity.java
+++ b/src/main/java/com/blog/som/domain/tag/entity/PostTagEntity.java
@@ -1,6 +1,8 @@
 package com.blog.som.domain.tag.entity;
 
+import com.blog.som.domain.member.entity.MemberEntity;
 import com.blog.som.domain.post.entity.PostEntity;
+import java.time.LocalDateTime;
 import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -37,9 +39,17 @@ public class PostTagEntity {
   @JoinColumn(name = "tag_id", nullable = false)
   private TagEntity tag;
 
-  public PostTagEntity(PostEntity post, TagEntity tag) {
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id", nullable = false)
+  private MemberEntity member;
+
+  private LocalDateTime postCreatedTime;
+
+  public PostTagEntity(PostEntity post, TagEntity tag, MemberEntity member) {
     this.post = post;
     this.tag = tag;
+    this.member = member;
+    this.postCreatedTime = post.getRegisteredAt();
   }
 
   @Override

--- a/src/main/java/com/blog/som/domain/tag/repository/PostTagRepository.java
+++ b/src/main/java/com/blog/som/domain/tag/repository/PostTagRepository.java
@@ -1,8 +1,12 @@
 package com.blog.som.domain.tag.repository;
 
+import com.blog.som.domain.member.entity.MemberEntity;
 import com.blog.som.domain.post.entity.PostEntity;
 import com.blog.som.domain.tag.entity.PostTagEntity;
+import com.blog.som.domain.tag.entity.TagEntity;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,4 +14,6 @@ import org.springframework.stereotype.Repository;
 public interface PostTagRepository extends JpaRepository<PostTagEntity, Long> {
 
   List<PostTagEntity> findAllByPost(PostEntity post);
+
+  Page<PostTagEntity> findByMemberAndTag(MemberEntity member, TagEntity tag, Pageable pageable);
 }

--- a/src/main/java/com/blog/som/global/constant/NumberConstant.java
+++ b/src/main/java/com/blog/som/global/constant/NumberConstant.java
@@ -1,0 +1,9 @@
+package com.blog.som.global.constant;
+
+public class NumberConstant {
+
+  private NumberConstant(){}
+
+  public static final int DEFAULT_PAGE_SIZE = 8;
+
+}

--- a/src/main/java/com/blog/som/global/dto/PageDto.java
+++ b/src/main/java/com/blog/som/global/dto/PageDto.java
@@ -1,0 +1,48 @@
+package com.blog.som.global.dto;
+
+import com.blog.som.domain.post.entity.PostEntity;
+import com.blog.som.domain.tag.entity.PostTagEntity;
+import org.springframework.data.domain.Page;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class PageDto {
+
+  private int currentPage; //현재 페이지
+  private int currentElements; //현재 페이지 데이터 개수
+  private int pageSize; //한 페이지 크기
+  private int totalElement; //전체 데이터 개수
+  private int totalPages; //전체 페이지 개수
+
+  public static PageDto fromPostEntityPage(Page<PostEntity> page){
+    return PageDto.builder()
+        .currentPage(page.getNumber() + 1)
+        .currentElements(page.getNumberOfElements())
+        .pageSize(page.getSize())
+        .totalElement((int)page.getTotalElements())
+        .totalPages(page.getTotalPages())
+        .build();
+  }
+
+  public static PageDto fromPostTagEntityEntityPage(Page<PostTagEntity> page){
+    return PageDto.builder()
+        .currentPage(page.getNumber() + 1)
+        .currentElements(page.getNumberOfElements())
+        .pageSize(page.getSize())
+        .totalElement((int)page.getTotalElements())
+        .totalPages(page.getTotalPages())
+        .build();
+  }
+
+
+
+}

--- a/src/main/java/com/blog/som/global/exception/ErrorCode.java
+++ b/src/main/java/com/blog/som/global/exception/ErrorCode.java
@@ -20,6 +20,12 @@ public enum ErrorCode{
   POST_EDIT_NO_AUTHORITY(HttpStatus.FORBIDDEN, "게시글 수정 권한이 없습니다."),
   POST_DELETE_NO_AUTHORITY(HttpStatus.FORBIDDEN, "게시글 삭제 권한이 없습니다."),
 
+  //Blog 관련
+  BLOG_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 블로그가 존재하지 않습니다."),
+  BLOG_POSTS_INVALID_QUERY(HttpStatus.BAD_REQUEST, "BLOG_POSTS_잘못된 쿼리 입니다."),
+  TAG_NOT_FOUND(HttpStatus.BAD_REQUEST, "tag를 찾을 수 없습니다."),
+
+
   //S3 image upload
   EMPTY_FILE_EXCEPTION(HttpStatus.BAD_REQUEST, "빈 파일 입니다."),
   NO_FILE_EXTENTION(HttpStatus.BAD_REQUEST, "파일 확장자가 존재하지 않습니다."),

--- a/src/main/java/com/blog/som/global/exception/custom/BlogException.java
+++ b/src/main/java/com/blog/som/global/exception/custom/BlogException.java
@@ -1,0 +1,23 @@
+package com.blog.som.global.exception.custom;
+
+import com.blog.som.global.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+public class BlogException extends RuntimeException{
+    private ErrorCode errorCode;
+    private String errorMessage;
+
+    public BlogException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+        this.errorMessage = errorCode.getDescription();
+    }
+}

--- a/src/main/java/com/blog/som/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/blog/som/global/exception/handler/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.blog.som.global.exception.handler;
 
 import com.blog.som.global.exception.ErrorCode;
 import com.blog.som.global.exception.ErrorResponse;
+import com.blog.som.global.exception.custom.BlogException;
 import com.blog.som.global.exception.custom.MemberException;
 import com.blog.som.global.exception.custom.CustomSecurityException;
 import com.blog.som.global.exception.custom.PostException;
@@ -33,6 +34,13 @@ public class GlobalExceptionHandler {
     ErrorResponse errorResponse = new ErrorResponse(e.getErrorCode(), e.getErrorMessage());
     return new ResponseEntity<>(errorResponse, e.getErrorCode().getStatus());
   }
+
+  @ExceptionHandler(BlogException.class)
+  public ResponseEntity<ErrorResponse> handleBlogException(BlogException e) {
+    ErrorResponse errorResponse = new ErrorResponse(e.getErrorCode(), e.getErrorMessage());
+    return new ResponseEntity<>(errorResponse, e.getErrorCode().getStatus());
+  }
+
 
   @ExceptionHandler(S3Exception.class)
   public ResponseEntity<ErrorResponse> handleS3Exception(S3Exception e) {


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요.  -->
### [블로그 메인 페이지]
블로그 메인 페이지에는 아래와 같은 데이터가 들어간다.
- 블로그 명, 프로필 사진, 회원 닉네임, 블로그 소개, 팔로잉, 팔로우
- 블로그에서 다룬 tag 리스트와 각각 tag가 붙은 게시글 수 
- 게시글 리스트

### [블로그 회원 정보 조회 API]
- `GET /blog/{accountName}/member`
- `accountName`으로 회원을 조회해서 회원 정보 DTO를 만든다.
- 팔로우와 팔로잉은 아직 0으로 설정해뒀다. 추후에 팔로잉 기능 구현 후 수정할 예정이다.

### [블로그 게시글 리스트 API 설명]
pageSize = 8 / page는 1부터 시작 / p : 페이지(default=1) / q : 검색어
- `쿼리 없음` : 전체 최신순 정렬
- `?tag=xxx&q=xxx` : (tag와 q가 동시에 들어오는 경우) 에러 발생
- `?sort=hot` : 무조건 조회수 순 정렬 (태그, 검색어 상관 없음)
->sort=hot 들어가면 다른건 다 무시됨. 조회수 순 인데, 태그는 어떻고 검색어는 어떻고 이런거 안됨
- `?tag=xxx` : 해당 태그(xxx)가 포함된 글 최신 순
- `?q=xxx` : 제목 또는 소개글에 xxx가 포함된 글 최신 순

### [ getBlogPostFromPostEntity(PostEntity postEntity) ]
- 모든 메서드에서 쓰이는 private 메서드이다.
- `PostEntity`가 들어가면 해당 post의 태그 정보를 조회하여 `BlogPostDto`를 만들어서 반환한다.

### [ getBlogPostListBySortType() ]
- 다른 query parameter는 들어오지 않았을 때 동작한다.
- `sort=hot` or `sort=latest` / latest는 default값이기도 하다.
- 각각 `조회수 순` , `최신 순`으로 게시글 List를 반환한다.

### [ getBlogPostListByTag() ]
- query paramerter로 `tag`가 들어왔을 때 동작한다. 항상 최신 순으로 정렬한다.
1. tagName으로 `TagEntity`를 찾는다.
2. `TagEntity`로 `Page<PostTagEntity>`를 찾는다.
3. `Page<PostTagEntity>` 를 `List<PostEntity>`로 변환한다.
4. private 메서드를 이용해서 `BlogPostDto`로 변환한다.

### [ getBlogPostListByQuery() ]
- query paramerter로 `q(검색어)`가 들어왔을 때 동작한다. 항상 최신 순으로 정렬한다.
- `Post(게시글)` 중, 제목(title) 또는 소개(introduction)에 검색어가 포함되는 List를 조회한다.

---

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
단위 테스트는 팔로우 기능 구현 후 진행 할 예정
- [ ] 테스트 코드
- [x] API 테스트 

