### PR TITLE
Feat : 팔로잉 API 구현

### DIFF
--- a/src/main/java/com/blog/som/domain/blog/dto/BlogMemberDto.java
+++ b/src/main/java/com/blog/som/domain/blog/dto/BlogMemberDto.java
@@ -19,16 +19,16 @@ public class BlogMemberDto {
   private String introduction;
 
   private int followerCount;
-  private int followCount;
+  private int followingCount;
 
-  public static BlogMemberDto fromEntity(MemberEntity member, int followCount, int followerCount){
+  public static BlogMemberDto fromEntity(MemberEntity member){
     return BlogMemberDto.builder()
         .blogName(member.getBlogName())
         .profileImage(member.getProfileImage())
         .nickname(member.getNickname())
         .introduction(member.getIntroduction())
-        .followerCount(followerCount)
-        .followCount(followCount)
+        .followerCount(member.getFollowerCount())
+        .followingCount(member.getFollowingCount())
         .build();
   }
 }

--- a/src/main/java/com/blog/som/domain/blog/service/BlogServiceImpl.java
+++ b/src/main/java/com/blog/som/domain/blog/service/BlogServiceImpl.java
@@ -38,7 +38,7 @@ public class BlogServiceImpl implements BlogService {
     MemberEntity member = memberRepository.findByAccountName(accountName)
         .orElseThrow(() -> new BlogException(ErrorCode.BLOG_NOT_FOUND));
 
-    return BlogMemberDto.fromEntity(member, 0, 0);
+    return BlogMemberDto.fromEntity(member);
   }
 
   @Override

--- a/src/main/java/com/blog/som/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/blog/som/domain/follow/controller/FollowController.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
@@ -36,7 +37,7 @@ public class FollowController {
 
   @ApiOperation("팔로우 취소")
   @PreAuthorize("hasAnyRole('ROLE_USER')")
-  @GetMapping("/follow/{accountName}")
+  @DeleteMapping("/follow/{accountName}")
   public ResponseEntity<FollowCancelResponse> cancelFollow(@PathVariable String accountName,
       @AuthenticationPrincipal LoginMember loginMember){
 

--- a/src/main/java/com/blog/som/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/blog/som/domain/follow/controller/FollowController.java
@@ -1,0 +1,37 @@
+package com.blog.som.domain.follow.controller;
+
+import com.blog.som.domain.follow.dto.FollowDto;
+import com.blog.som.domain.follow.service.FollowService;
+import com.blog.som.domain.member.security.userdetails.LoginMember;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@Api(tags = "게시글(post)")
+@RequiredArgsConstructor
+@RestController
+public class FollowController {
+
+  private final FollowService followService;
+
+  @ApiOperation("팔로우 하기")
+  @PreAuthorize("hasAnyRole('ROLE_USER')")
+  @GetMapping("/follow/{accountName}")
+  public ResponseEntity<FollowDto> doFollow(@PathVariable String accountName,
+      @AuthenticationPrincipal LoginMember loginMember){
+
+    FollowDto follow = followService.doFollow(loginMember.getMemberId(), accountName);
+
+    return ResponseEntity.ok(follow);
+  }
+
+
+}

--- a/src/main/java/com/blog/som/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/blog/som/domain/follow/controller/FollowController.java
@@ -1,5 +1,6 @@
 package com.blog.som.domain.follow.controller;
 
+import com.blog.som.domain.follow.dto.FollowCancelResponse;
 import com.blog.som.domain.follow.dto.FollowDto;
 import com.blog.som.domain.follow.service.FollowService;
 import com.blog.som.domain.member.security.userdetails.LoginMember;
@@ -31,6 +32,17 @@ public class FollowController {
     FollowDto follow = followService.doFollow(loginMember.getMemberId(), accountName);
 
     return ResponseEntity.ok(follow);
+  }
+
+  @ApiOperation("팔로우 취소")
+  @PreAuthorize("hasAnyRole('ROLE_USER')")
+  @GetMapping("/follow/{accountName}")
+  public ResponseEntity<FollowCancelResponse> cancelFollow(@PathVariable String accountName,
+      @AuthenticationPrincipal LoginMember loginMember){
+
+    FollowCancelResponse response = followService.cancelFollow(loginMember.getMemberId(), accountName);
+
+    return ResponseEntity.ok(response);
   }
 
 

--- a/src/main/java/com/blog/som/domain/follow/dto/FollowCancelResponse.java
+++ b/src/main/java/com/blog/som/domain/follow/dto/FollowCancelResponse.java
@@ -1,0 +1,28 @@
+package com.blog.som.domain.follow.dto;
+
+import com.blog.som.domain.follow.entity.FollowEntity;
+import com.blog.som.global.constant.ResponseConstant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class FollowCancelResponse {
+  private Long fromMemberId;
+  private Long toMemberId;
+  private String message;
+
+  public static FollowCancelResponse fromEntity(FollowEntity follow){
+    return FollowCancelResponse.builder()
+        .fromMemberId(follow.getFromMember().getMemberId())
+        .toMemberId(follow.getToMember().getMemberId())
+        .message(ResponseConstant.FOLLOW_CANCEL_COMPLETE)
+        .build();
+  }
+}

--- a/src/main/java/com/blog/som/domain/follow/dto/FollowDto.java
+++ b/src/main/java/com/blog/som/domain/follow/dto/FollowDto.java
@@ -1,0 +1,38 @@
+package com.blog.som.domain.follow.dto;
+
+import com.blog.som.domain.follow.entity.FollowEntity;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class FollowDto {
+
+  private Long followId;
+
+  private Long fromMemberId;
+
+  private Long toMemberId;
+
+  private String toMemberBlogName;
+
+  private LocalDateTime followAt;
+
+  public static FollowDto fromEntity(FollowEntity follow){
+    return FollowDto.builder()
+        .followId(follow.getFollowId())
+        .fromMemberId(follow.getFromMember().getMemberId())
+        .toMemberId(follow.getToMember().getMemberId())
+        .toMemberBlogName(follow.getToMember().getBlogName())
+        .followAt(follow.getFollowAt())
+        .build();
+  }
+
+}

--- a/src/main/java/com/blog/som/domain/follow/entity/FollowEntity.java
+++ b/src/main/java/com/blog/som/domain/follow/entity/FollowEntity.java
@@ -1,0 +1,69 @@
+package com.blog.som.domain.follow.entity;
+
+import com.blog.som.domain.member.entity.MemberEntity;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "follow")
+@EntityListeners(AuditingEntityListener.class)
+public class FollowEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "follow_id", nullable = false)
+  private Long followId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "from_member_id", nullable = false)
+  private MemberEntity fromMember;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "to_member_id", nullable = false)
+  private MemberEntity toMember;
+
+  @CreatedDate
+  private LocalDateTime followAt;
+
+  public FollowEntity(MemberEntity fromMember, MemberEntity toMember) {
+    this.fromMember = fromMember;
+    this.toMember = toMember;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    FollowEntity that = (FollowEntity) o;
+    return Objects.equals(followId, that.followId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(followId);
+  }
+}

--- a/src/main/java/com/blog/som/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/blog/som/domain/follow/repository/FollowRepository.java
@@ -1,0 +1,11 @@
+package com.blog.som.domain.follow.repository;
+
+import com.blog.som.domain.follow.entity.FollowEntity;
+import com.blog.som.domain.member.entity.MemberEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FollowRepository extends JpaRepository<FollowEntity, Long> {
+  boolean existsByFromMemberAndToMember(MemberEntity fromMember, MemberEntity toMember);
+}

--- a/src/main/java/com/blog/som/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/blog/som/domain/follow/repository/FollowRepository.java
@@ -2,10 +2,12 @@ package com.blog.som.domain.follow.repository;
 
 import com.blog.som.domain.follow.entity.FollowEntity;
 import com.blog.som.domain.member.entity.MemberEntity;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface FollowRepository extends JpaRepository<FollowEntity, Long> {
   boolean existsByFromMemberAndToMember(MemberEntity fromMember, MemberEntity toMember);
+  Optional<FollowEntity> findByFromMemberAndToMember(MemberEntity fromMember, MemberEntity toMember);
 }

--- a/src/main/java/com/blog/som/domain/follow/service/FollowService.java
+++ b/src/main/java/com/blog/som/domain/follow/service/FollowService.java
@@ -1,5 +1,6 @@
 package com.blog.som.domain.follow.service;
 
+import com.blog.som.domain.follow.dto.FollowCancelResponse;
 import com.blog.som.domain.follow.dto.FollowDto;
 
 public interface FollowService {
@@ -9,4 +10,8 @@ public interface FollowService {
    */
   FollowDto doFollow(Long fromMemberId, String blogAccountName);
 
+  /**
+   * follow 취소
+   */
+  FollowCancelResponse cancelFollow(Long fromMemberId, String blogAccountName);
 }

--- a/src/main/java/com/blog/som/domain/follow/service/FollowService.java
+++ b/src/main/java/com/blog/som/domain/follow/service/FollowService.java
@@ -1,0 +1,12 @@
+package com.blog.som.domain.follow.service;
+
+import com.blog.som.domain.follow.dto.FollowDto;
+
+public interface FollowService {
+
+  /**
+   * follow 하기
+   */
+  FollowDto doFollow(Long fromMemberId, String blogAccountName);
+
+}

--- a/src/main/java/com/blog/som/domain/follow/service/FollowServiceImpl.java
+++ b/src/main/java/com/blog/som/domain/follow/service/FollowServiceImpl.java
@@ -1,0 +1,46 @@
+package com.blog.som.domain.follow.service;
+
+import com.blog.som.domain.follow.dto.FollowDto;
+import com.blog.som.domain.follow.entity.FollowEntity;
+import com.blog.som.domain.follow.repository.FollowRepository;
+import com.blog.som.domain.member.entity.MemberEntity;
+import com.blog.som.domain.member.repository.MemberRepository;
+import com.blog.som.global.exception.ErrorCode;
+import com.blog.som.global.exception.custom.BlogException;
+import com.blog.som.global.exception.custom.FollowException;
+import com.blog.som.global.exception.custom.MemberException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class FollowServiceImpl implements FollowService{
+
+  private final FollowRepository followRepository;
+  private final MemberRepository memberRepository;
+
+  @Override
+  public FollowDto doFollow(Long fromMemberId, String blogAccountName) {
+    MemberEntity fromMember = memberRepository.findById(fromMemberId)
+        .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+    MemberEntity toMember = memberRepository.findByAccountName(blogAccountName)
+        .orElseThrow(() -> new BlogException(ErrorCode.BLOG_NOT_FOUND));
+
+    if(followRepository.existsByFromMemberAndToMember(fromMember, toMember)){
+      throw new FollowException(ErrorCode.ALREADY_FOLLOWED);
+    }
+    fromMember.addFollowingCount();
+    toMember.addFollowerCount();
+
+    FollowEntity saved = followRepository.save(new FollowEntity(fromMember, toMember));
+
+    memberRepository.save(fromMember);
+    memberRepository.save(toMember);
+
+    return FollowDto.fromEntity(saved);
+  }
+}

--- a/src/main/java/com/blog/som/domain/member/dto/MemberDto.java
+++ b/src/main/java/com/blog/som/domain/member/dto/MemberDto.java
@@ -30,6 +30,10 @@ public class MemberDto {
 
   private String profileImage;
 
+  private int followingCount;
+
+  private int followerCount;
+
   private LocalDateTime registeredAt;
 
   private Role role;
@@ -43,6 +47,8 @@ public class MemberDto {
         .blogName(member.getBlogName())
         .introduction(member.getIntroduction())
         .profileImage(member.getProfileImage())
+        .followingCount(member.getFollowingCount())
+        .followerCount(member.getFollowerCount())
         .registeredAt(member.getRegisteredAt())
         .role(member.getRole())
         .build();

--- a/src/main/java/com/blog/som/domain/member/entity/MemberEntity.java
+++ b/src/main/java/com/blog/som/domain/member/entity/MemberEntity.java
@@ -78,8 +78,21 @@ public class MemberEntity {
   public void addFollowerCount(){
     this.followerCount += 1;
   }
+
   public void addFollowingCount(){
     this.followingCount += 1;
+  }
+
+  public void minusFollowerCount(){
+    if(this.followerCount > 0){
+      this.followerCount -= 1;
+    }
+  }
+
+  public void minusFollowingCount(){
+    if(this.followingCount > 0){
+      this.followingCount -= 1;
+    }
   }
 
   @Override

--- a/src/main/java/com/blog/som/domain/member/entity/MemberEntity.java
+++ b/src/main/java/com/blog/som/domain/member/entity/MemberEntity.java
@@ -55,6 +55,12 @@ public class MemberEntity {
   @Column(name = "profile_image")
   private String profileImage;
 
+  @Column(name = "following")
+  private int followingCount;
+
+  @Column(name = "follower")
+  private int followerCount;
+
   @Column(name = "registered_at", nullable = false)
   @CreatedDate
   private LocalDateTime registeredAt;
@@ -67,6 +73,13 @@ public class MemberEntity {
     this.nickname = request.getNickname();
     this.introduction = request.getIntroduction();
     this.blogName = request.getBlogName();
+  }
+
+  public void addFollowerCount(){
+    this.followerCount += 1;
+  }
+  public void addFollowingCount(){
+    this.followingCount += 1;
   }
 
   @Override

--- a/src/main/java/com/blog/som/global/constant/ResponseConstant.java
+++ b/src/main/java/com/blog/som/global/constant/ResponseConstant.java
@@ -6,5 +6,6 @@ public class ResponseConstant {
   public static final String EMAIL_AUTH_COMPLETE = "이메일 인증이 완료되었습니다.";
   public static final String EMAIL_AUTH_ALREADY_COMPLETED = "이미 이메일 인증이 완료된 회원입니다.";
   public static final String PASSWORD_EDIT_COMPLETE = "비밀번호 변경이 완료되었습니다.";
+  public static final String FOLLOW_CANCEL_COMPLETE = "팔로우 취소가 완료되었습니다.";
 
 }

--- a/src/main/java/com/blog/som/global/exception/ErrorCode.java
+++ b/src/main/java/com/blog/som/global/exception/ErrorCode.java
@@ -25,6 +25,9 @@ public enum ErrorCode{
   BLOG_POSTS_INVALID_QUERY(HttpStatus.BAD_REQUEST, "BLOG_POSTS_잘못된 쿼리 입니다."),
   TAG_NOT_FOUND(HttpStatus.BAD_REQUEST, "tag를 찾을 수 없습니다."),
 
+  //Follow 관련
+  ALREADY_FOLLOWED(HttpStatus.CONFLICT, "이미 팔로우 된 블로그입니다."),
+
 
   //S3 image upload
   EMPTY_FILE_EXCEPTION(HttpStatus.BAD_REQUEST, "빈 파일 입니다."),

--- a/src/main/java/com/blog/som/global/exception/ErrorCode.java
+++ b/src/main/java/com/blog/som/global/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode{
 
   //Follow 관련
   ALREADY_FOLLOWED(HttpStatus.CONFLICT, "이미 팔로우 된 블로그입니다."),
+  FOLLOW_NOT_FOUND(HttpStatus.BAD_REQUEST, "팔로우 되어 있지 않은 상태 입니다."),
 
 
   //S3 image upload

--- a/src/main/java/com/blog/som/global/exception/custom/FollowException.java
+++ b/src/main/java/com/blog/som/global/exception/custom/FollowException.java
@@ -1,0 +1,23 @@
+package com.blog.som.global.exception.custom;
+
+import com.blog.som.global.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+public class FollowException extends RuntimeException{
+    private ErrorCode errorCode;
+    private String errorMessage;
+
+    public FollowException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+        this.errorMessage = errorCode.getDescription();
+    }
+}

--- a/src/main/java/com/blog/som/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/blog/som/global/exception/handler/GlobalExceptionHandler.java
@@ -1,8 +1,8 @@
 package com.blog.som.global.exception.handler;
 
-import com.blog.som.global.exception.ErrorCode;
 import com.blog.som.global.exception.ErrorResponse;
 import com.blog.som.global.exception.custom.BlogException;
+import com.blog.som.global.exception.custom.FollowException;
 import com.blog.som.global.exception.custom.MemberException;
 import com.blog.som.global.exception.custom.CustomSecurityException;
 import com.blog.som.global.exception.custom.PostException;
@@ -16,12 +16,12 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-  @ExceptionHandler(Exception.class)
-  public ResponseEntity<ErrorResponse> handleException(Exception e) {
-    ErrorResponse errorResponse = new ErrorResponse(ErrorCode.INTERNAL_SERVER_ERROR,
-        e.getMessage());
-    return new ResponseEntity<>(errorResponse, errorResponse.getErrorCode().getStatus());
-  }
+//  @ExceptionHandler(Exception.class)
+//  public ResponseEntity<ErrorResponse> handleException(Exception e) {
+//    ErrorResponse errorResponse = new ErrorResponse(ErrorCode.INTERNAL_SERVER_ERROR,
+//        e.getMessage());
+//    return new ResponseEntity<>(errorResponse, errorResponse.getErrorCode().getStatus());
+//  }
 
   @ExceptionHandler(MemberException.class)
   public ResponseEntity<ErrorResponse> handleMemberException(MemberException e) {
@@ -37,6 +37,12 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler(BlogException.class)
   public ResponseEntity<ErrorResponse> handleBlogException(BlogException e) {
+    ErrorResponse errorResponse = new ErrorResponse(e.getErrorCode(), e.getErrorMessage());
+    return new ResponseEntity<>(errorResponse, e.getErrorCode().getStatus());
+  }
+
+  @ExceptionHandler(FollowException.class)
+  public ResponseEntity<ErrorResponse> handleFollowException(FollowException e) {
     ErrorResponse errorResponse = new ErrorResponse(e.getErrorCode(), e.getErrorMessage());
     return new ResponseEntity<>(errorResponse, e.getErrorCode().getStatus());
   }

--- a/src/test/java/com/blog/som/EntityCreator.java
+++ b/src/test/java/com/blog/som/EntityCreator.java
@@ -1,5 +1,6 @@
 package com.blog.som;
 
+import com.blog.som.domain.follow.entity.FollowEntity;
 import com.blog.som.domain.member.entity.MemberEntity;
 import com.blog.som.domain.member.type.Role;
 import com.blog.som.domain.post.entity.PostEntity;
@@ -19,6 +20,8 @@ public class EntityCreator {
         .blogName("testAccountName" + id + ".som")
         .introduction("hello" + id)
         .profileImage("test-profile-image" + id + ".jpg")
+        .followerCount(0)
+        .followingCount(0)
         .registeredAt(LocalDateTime.now())
         .role(Role.USER)
         .build();
@@ -50,6 +53,15 @@ public class EntityCreator {
         .postTagId(id)
         .post(post)
         .tag(tag)
+        .build();
+  }
+
+  public static FollowEntity createFollowEntity(Long id, MemberEntity fromMember, MemberEntity toMember){
+    return FollowEntity.builder()
+        .followId(id)
+        .fromMember(fromMember)
+        .toMember(toMember)
+        .followAt(LocalDateTime.now())
         .build();
   }
 }

--- a/src/test/java/com/blog/som/domain/follow/service/FollowServiceTest.java
+++ b/src/test/java/com/blog/som/domain/follow/service/FollowServiceTest.java
@@ -1,0 +1,136 @@
+package com.blog.som.domain.follow.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import com.blog.som.EntityCreator;
+import com.blog.som.domain.follow.dto.FollowDto;
+import com.blog.som.domain.follow.entity.FollowEntity;
+import com.blog.som.domain.follow.repository.FollowRepository;
+import com.blog.som.domain.member.entity.MemberEntity;
+import com.blog.som.domain.member.repository.MemberRepository;
+import com.blog.som.global.exception.ErrorCode;
+import com.blog.som.global.exception.custom.BlogException;
+import com.blog.som.global.exception.custom.FollowException;
+import com.blog.som.global.exception.custom.MemberException;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@Slf4j
+@ExtendWith(MockitoExtension.class)
+class FollowServiceTest {
+
+  @Mock
+  private FollowRepository followRepository;
+  @Mock
+  private MemberRepository memberRepository;
+
+  @InjectMocks
+  private FollowServiceImpl followService;
+
+
+  @Nested
+  @DisplayName("팔로우 하기")
+  class DoFollow{
+
+    @Test
+    @DisplayName("성공")
+    void doFollow(){
+      MemberEntity fromMember = EntityCreator.createMember(1L);
+      MemberEntity toMember = EntityCreator.createMember(2L);
+      FollowEntity followEntity = EntityCreator.createFollowEntity(10L, fromMember, toMember);
+
+      //given
+      when(memberRepository.findById(1L))
+          .thenReturn(Optional.of(fromMember));
+      when(memberRepository.findByAccountName(toMember.getAccountName()))
+          .thenReturn(Optional.of(toMember));
+      when(followRepository.existsByFromMemberAndToMember(fromMember, toMember))
+          .thenReturn(false);
+      when(followRepository.save(new FollowEntity(fromMember, toMember)))
+          .thenReturn(followEntity);
+      //when
+      FollowDto followDto = followService.doFollow(1L, toMember.getAccountName());
+
+      //then
+      verify(memberRepository, times(2)).save(any(MemberEntity.class));
+      assertThat(followDto.getFromMemberId()).isEqualTo(1L);
+      assertThat(followDto.getToMemberId()).isEqualTo(2L);
+      assertThat(followDto.getToMemberBlogName()).isEqualTo(toMember.getBlogName());
+    }
+
+    @Test
+    @DisplayName("실패 : MEMBER_NOT_FOUND")
+    void doFollow_MEMBER_NOT_FOUND(){
+      MemberEntity fromMember = EntityCreator.createMember(1L);
+      MemberEntity toMember = EntityCreator.createMember(2L);
+      FollowEntity followEntity = EntityCreator.createFollowEntity(10L, fromMember, toMember);
+
+      //given
+      when(memberRepository.findById(1L))
+          .thenReturn(Optional.empty());
+
+      //when
+      //then
+      MemberException memberException = assertThrows(MemberException.class,
+          () -> followService.doFollow(1L, toMember.getAccountName()));
+      assertThat(memberException.getErrorCode()).isEqualTo(ErrorCode.MEMBER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("실패 : BLOG_NOT_FOUND")
+    void doFollow_BLOG_NOT_FOUND(){
+      MemberEntity fromMember = EntityCreator.createMember(1L);
+      MemberEntity toMember = EntityCreator.createMember(2L);
+      FollowEntity followEntity = EntityCreator.createFollowEntity(10L, fromMember, toMember);
+
+      //given
+      when(memberRepository.findById(1L))
+          .thenReturn(Optional.of(fromMember));
+      when(memberRepository.findByAccountName(toMember.getAccountName()))
+          .thenReturn(Optional.empty());
+
+      //when
+      //then
+      BlogException blogException = assertThrows(BlogException.class,
+          () -> followService.doFollow(1L, toMember.getAccountName()));
+      verify(memberRepository, never()).save(fromMember);
+      assertThat(blogException.getErrorCode()).isEqualTo(ErrorCode.BLOG_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("실패 : ALREADY_FOLLOWED")
+    void doFollow_ALREADY_FOLLOWED(){
+      MemberEntity fromMember = EntityCreator.createMember(1L);
+      MemberEntity toMember = EntityCreator.createMember(2L);
+      FollowEntity followEntity = EntityCreator.createFollowEntity(10L, fromMember, toMember);
+
+      //given
+      when(memberRepository.findById(1L))
+          .thenReturn(Optional.of(fromMember));
+      when(memberRepository.findByAccountName(toMember.getAccountName()))
+          .thenReturn(Optional.of(toMember));
+      when(followRepository.existsByFromMemberAndToMember(fromMember, toMember))
+          .thenReturn(true);
+
+      //when
+      //then
+      FollowException followException = assertThrows(FollowException.class,
+          () -> followService.doFollow(1L, toMember.getAccountName()));
+      verify(memberRepository, never()).save(fromMember);
+      assertThat(followException.getErrorCode()).isEqualTo(ErrorCode.ALREADY_FOLLOWED);
+    }
+
+  }
+
+}

--- a/src/test/java/com/blog/som/domain/follow/service/FollowServiceTest.java
+++ b/src/test/java/com/blog/som/domain/follow/service/FollowServiceTest.java
@@ -1,27 +1,31 @@
 package com.blog.som.domain.follow.service;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.BDDMockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.never;
+import static org.mockito.BDDMockito.times;
+import static org.mockito.BDDMockito.verify;
+import static org.mockito.BDDMockito.when;
 
 import com.blog.som.EntityCreator;
+import com.blog.som.domain.follow.dto.FollowCancelResponse;
 import com.blog.som.domain.follow.dto.FollowDto;
 import com.blog.som.domain.follow.entity.FollowEntity;
 import com.blog.som.domain.follow.repository.FollowRepository;
 import com.blog.som.domain.member.entity.MemberEntity;
 import com.blog.som.domain.member.repository.MemberRepository;
+import com.blog.som.global.constant.ResponseConstant;
 import com.blog.som.global.exception.ErrorCode;
 import com.blog.som.global.exception.custom.BlogException;
 import com.blog.som.global.exception.custom.FollowException;
 import com.blog.som.global.exception.custom.MemberException;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -41,11 +45,11 @@ class FollowServiceTest {
 
   @Nested
   @DisplayName("팔로우 하기")
-  class DoFollow{
+  class DoFollow {
 
     @Test
     @DisplayName("성공")
-    void doFollow(){
+    void doFollow() {
       MemberEntity fromMember = EntityCreator.createMember(1L);
       MemberEntity toMember = EntityCreator.createMember(2L);
       FollowEntity followEntity = EntityCreator.createFollowEntity(10L, fromMember, toMember);
@@ -71,7 +75,7 @@ class FollowServiceTest {
 
     @Test
     @DisplayName("실패 : MEMBER_NOT_FOUND")
-    void doFollow_MEMBER_NOT_FOUND(){
+    void doFollow_MEMBER_NOT_FOUND() {
       MemberEntity fromMember = EntityCreator.createMember(1L);
       MemberEntity toMember = EntityCreator.createMember(2L);
       FollowEntity followEntity = EntityCreator.createFollowEntity(10L, fromMember, toMember);
@@ -89,7 +93,7 @@ class FollowServiceTest {
 
     @Test
     @DisplayName("실패 : BLOG_NOT_FOUND")
-    void doFollow_BLOG_NOT_FOUND(){
+    void doFollow_BLOG_NOT_FOUND() {
       MemberEntity fromMember = EntityCreator.createMember(1L);
       MemberEntity toMember = EntityCreator.createMember(2L);
       FollowEntity followEntity = EntityCreator.createFollowEntity(10L, fromMember, toMember);
@@ -110,7 +114,7 @@ class FollowServiceTest {
 
     @Test
     @DisplayName("실패 : ALREADY_FOLLOWED")
-    void doFollow_ALREADY_FOLLOWED(){
+    void doFollow_ALREADY_FOLLOWED() {
       MemberEntity fromMember = EntityCreator.createMember(1L);
       MemberEntity toMember = EntityCreator.createMember(2L);
       FollowEntity followEntity = EntityCreator.createFollowEntity(10L, fromMember, toMember);
@@ -130,7 +134,99 @@ class FollowServiceTest {
       verify(memberRepository, never()).save(fromMember);
       assertThat(followException.getErrorCode()).isEqualTo(ErrorCode.ALREADY_FOLLOWED);
     }
+  }
 
+  @Nested
+  @DisplayName("팔로우 취소")
+  class CancelFollow {
+
+    @Test
+    @DisplayName("성공")
+    void cancelFollow() {
+      MemberEntity fromMember = EntityCreator.createMember(1L);
+      MemberEntity toMember = EntityCreator.createMember(2L);
+      FollowEntity followEntity = EntityCreator.createFollowEntity(10L, fromMember, toMember);
+
+      //given
+      when(memberRepository.findById(1L))
+          .thenReturn(Optional.of(fromMember));
+      when(memberRepository.findByAccountName(toMember.getAccountName()))
+          .thenReturn(Optional.of(toMember));
+      when(followRepository.findByFromMemberAndToMember(fromMember, toMember))
+          .thenReturn(Optional.of(followEntity));
+
+      //when
+      FollowCancelResponse response = followService.cancelFollow(1L, toMember.getAccountName());
+
+      //then
+      verify(followRepository, times(1)).delete(followEntity);
+      verify(memberRepository, times(2)).save(any(MemberEntity.class));
+      assertThat(response.getFromMemberId()).isEqualTo(fromMember.getMemberId());
+      assertThat(response.getToMemberId()).isEqualTo(toMember.getMemberId());
+      assertThat(response.getMessage()).isEqualTo(ResponseConstant.FOLLOW_CANCEL_COMPLETE);
+    }
+
+    @Test
+    @DisplayName("실패 : MEMBER_NOT_FOUND")
+    void cancelFollow_MEMBER_NOT_FOUND() {
+      MemberEntity fromMember = EntityCreator.createMember(1L);
+      MemberEntity toMember = EntityCreator.createMember(2L);
+      FollowEntity followEntity = EntityCreator.createFollowEntity(10L, fromMember, toMember);
+
+      //given
+      when(memberRepository.findById(1L))
+          .thenReturn(Optional.empty());
+
+      //when
+      //then
+      MemberException memberException = assertThrows(MemberException.class,
+          () -> followService.cancelFollow(1L, toMember.getAccountName()));
+      assertThat(memberException.getErrorCode()).isEqualTo(ErrorCode.MEMBER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("실패 : BLOG_NOT_FOUND")
+    void cancelFollow_BLOG_NOT_FOUND() {
+      MemberEntity fromMember = EntityCreator.createMember(1L);
+      MemberEntity toMember = EntityCreator.createMember(2L);
+      FollowEntity followEntity = EntityCreator.createFollowEntity(10L, fromMember, toMember);
+
+      //given
+      when(memberRepository.findById(1L))
+          .thenReturn(Optional.of(fromMember));
+      when(memberRepository.findByAccountName(toMember.getAccountName()))
+          .thenReturn(Optional.empty());
+
+      //when
+      //then
+      BlogException blogException = assertThrows(BlogException.class,
+          () -> followService.cancelFollow(1L, toMember.getAccountName()));
+      verify(memberRepository, never()).save(fromMember);
+      assertThat(blogException.getErrorCode()).isEqualTo(ErrorCode.BLOG_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("실패 : FOLLOW_NOT_FOUND")
+    void cancelFollow_FOLLOW_NOT_FOUND() {
+      MemberEntity fromMember = EntityCreator.createMember(1L);
+      MemberEntity toMember = EntityCreator.createMember(2L);
+      FollowEntity followEntity = EntityCreator.createFollowEntity(10L, fromMember, toMember);
+
+      //given
+      when(memberRepository.findById(1L))
+          .thenReturn(Optional.of(fromMember));
+      when(memberRepository.findByAccountName(toMember.getAccountName()))
+          .thenReturn(Optional.of(toMember));
+      when(followRepository.findByFromMemberAndToMember(fromMember, toMember))
+          .thenReturn(Optional.empty());
+
+      //when
+      //then
+      FollowException followException = assertThrows(FollowException.class,
+          () -> followService.cancelFollow(1L, toMember.getAccountName()));
+      verify(memberRepository, never()).save(fromMember);
+      assertThat(followException.getErrorCode()).isEqualTo(ErrorCode.FOLLOW_NOT_FOUND);
+    }
   }
 
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요.  -->
### [팔로잉, 팔로워 수]
- 팔로잉, 팔로워 수를 MemberEntity에 추가했다.
- 직전 PR에서 개발했던 BlogService.getBlogMember()에서 팔로워, 팔로잉 수를 MemberEntity에서 가져오도록 수정했다.

### [팔로우 하기]
- `fromMember` : 로그인 유저
- `toMember` : `{accountName}`에 해당하는 유저
- 팔로우 수락/거절은 없다.

### [팔로우 취소]
- `fromMember` : 로그인 유저
- `toMember` : `{accountName}`에 해당하는 유저
- 팔로우를 취소한다.

---

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 

