### PR TITLE
Feat : 메인 페이지 조회 API 구현, Blog 페이지 조회 API 리팩터링

### DIFF
--- a/src/main/java/com/blog/som/domain/blog/controller/BlogController.java
+++ b/src/main/java/com/blog/som/domain/blog/controller/BlogController.java
@@ -52,6 +52,10 @@ public class BlogController {
       @RequestParam(value = "tag", required = false, defaultValue = "") String tagName,
       @RequestParam(value = "q", required = false, defaultValue = "")String query,
       @RequestParam(value = "p",required = false, defaultValue = "1") int page){
+    
+    //accountName이 존재하는지 검증
+    blogService.validateAccountName(accountName);
+    
     //두가지 모두 query로 들어올 순 없음
     if (StringUtils.hasText(tagName) && StringUtils.hasText(query)) {
       throw new BlogException(ErrorCode.BLOG_POSTS_INVALID_QUERY);

--- a/src/main/java/com/blog/som/domain/blog/service/BlogService.java
+++ b/src/main/java/com/blog/som/domain/blog/service/BlogService.java
@@ -11,6 +11,12 @@ public interface BlogService {
    */
   BlogMemberDto getBlogMember(String accountName);
 
+
+  /**
+   * 블로그 명 (accountName)이 유효한 지 검증
+   */
+  void validateAccountName(String accountName);
+
   /**
    * 로그인 유저의 팔로우 여부
    */

--- a/src/main/java/com/blog/som/domain/blog/service/BlogServiceImpl.java
+++ b/src/main/java/com/blog/som/domain/blog/service/BlogServiceImpl.java
@@ -46,6 +46,13 @@ public class BlogServiceImpl implements BlogService {
   }
 
   @Override
+  public void validateAccountName(String accountName) {
+    if(!memberRepository.existsByAccountName(accountName)){
+      throw new BlogException(ErrorCode.BLOG_NOT_FOUND);
+    }
+  }
+
+  @Override
   public String getFollowStatus(Long memberId, String accountName) {
     boolean result = followService.isFollowing(memberId, accountName);
     if(result){

--- a/src/main/java/com/blog/som/domain/blog/service/ElasticsearchBlogService.java
+++ b/src/main/java/com/blog/som/domain/blog/service/ElasticsearchBlogService.java
@@ -33,7 +33,7 @@ public class ElasticsearchBlogService implements BlogService {
   private final MemberRepository memberRepository;
   private final PostRepository postRepository;
   private final FollowService followService;
-  private final ElasticsearchPostRepository elasticSearchPostRepository;
+  private final ElasticsearchPostRepository elasticsearchPostRepository;
 
   @Override
   public BlogMemberDto getBlogMember(String accountName) {
@@ -62,7 +62,7 @@ public class ElasticsearchBlogService implements BlogService {
 
     PageRequest pageRequest = PageRequest.of(page - 1, NumberConstant.DEFAULT_PAGE_SIZE, Sort.by(sortBy).descending());
 
-    Page<PostDocument> documents = elasticSearchPostRepository.findAllByAccountName(accountName, pageRequest);
+    Page<PostDocument> documents = elasticsearchPostRepository.findAllByAccountName(accountName, pageRequest);
 
     List<BlogPostDto> blogPostDtoList =
         documents.getContent()
@@ -77,7 +77,7 @@ public class ElasticsearchBlogService implements BlogService {
         PageRequest.of(page - 1, NumberConstant.DEFAULT_PAGE_SIZE,
             Sort.by(SearchConstant.REGISTERED_AT).descending());
 
-    Page<PostDocument> pageDocument = elasticSearchPostRepository.findByAccountNameAndTagsContaining(
+    Page<PostDocument> pageDocument = elasticsearchPostRepository.findByAccountNameAndTagsContaining(
         accountName, tagName, pageRequest);
     List<BlogPostDto> blogPostDtoList = pageDocument.getContent().stream().map(BlogPostDto::fromDocument).toList();
 
@@ -99,7 +99,7 @@ public class ElasticsearchBlogService implements BlogService {
 
     List<BlogPostDto> blogPostDtoList =
         posts.stream()
-            .map(p -> elasticSearchPostRepository.findById(p.getPostId()))
+            .map(p -> elasticsearchPostRepository.findById(p.getPostId()))
             .filter(Optional::isPresent)
             .map(op -> BlogPostDto.fromDocument(op.get()))
             .toList();

--- a/src/main/java/com/blog/som/domain/blog/service/ElasticsearchBlogService.java
+++ b/src/main/java/com/blog/som/domain/blog/service/ElasticsearchBlogService.java
@@ -40,6 +40,13 @@ public class ElasticsearchBlogService implements BlogService {
   }
 
   @Override
+  public void validateAccountName(String accountName) {
+    if(!memberRepository.existsByAccountName(accountName)){
+      throw new BlogException(ErrorCode.BLOG_NOT_FOUND);
+    }
+  }
+
+  @Override
   public String getFollowStatus(Long memberId, String accountName) {
     boolean result = followService.isFollowing(memberId, accountName);
     if (result) {
@@ -77,9 +84,6 @@ public class ElasticsearchBlogService implements BlogService {
 
   @Override
   public BlogPostList getBlogPostListByQuery(String accountName, String query, int page) {
-    MemberEntity member = memberRepository.findByAccountName(accountName)
-        .orElseThrow(() -> new BlogException(ErrorCode.BLOG_NOT_FOUND));
-
     PageRequest pageRequest =
         PageRequest.of(page - 1, NumberConstant.DEFAULT_PAGE_SIZE,
             Sort.by(SearchConstant.REGISTERED_AT).descending());

--- a/src/main/java/com/blog/som/domain/main/controller/MainController.java
+++ b/src/main/java/com/blog/som/domain/main/controller/MainController.java
@@ -1,0 +1,30 @@
+package com.blog.som.domain.main.controller;
+
+import com.blog.som.domain.blog.dto.BlogPostList;
+import com.blog.som.domain.main.service.MainService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@Api(tags = "SOM 메인(main)")
+@RequiredArgsConstructor
+@RestController
+public class MainController {
+
+  private final MainService mainService;
+
+  @ApiOperation("메인 페이지")
+  @GetMapping("/main")
+  public ResponseEntity<BlogPostList> mainPage(@RequestParam(required = false, defaultValue = "hot") String sort,
+      @RequestParam(value = "p",required = false, defaultValue = "1") int page){
+    BlogPostList mainPageList = mainService.getMainPageList(sort, page);
+
+    return ResponseEntity.ok(mainPageList);
+  }
+}

--- a/src/main/java/com/blog/som/domain/main/controller/MainController.java
+++ b/src/main/java/com/blog/som/domain/main/controller/MainController.java
@@ -7,6 +7,7 @@ import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,9 +23,40 @@ public class MainController {
   @ApiOperation("메인 페이지")
   @GetMapping("/main")
   public ResponseEntity<BlogPostList> mainPage(@RequestParam(required = false, defaultValue = "hot") String sort,
-      @RequestParam(value = "p",required = false, defaultValue = "1") int page){
-    BlogPostList mainPageList = mainService.getMainPageList(sort, page);
+      @RequestParam(value = "p", required = false, defaultValue = "1") int page) {
 
-    return ResponseEntity.ok(mainPageList);
+    if (sort.equals("latest")) {
+      return ResponseEntity.ok(mainService.getAllPostListLatest(page));
+    }
+
+    return ResponseEntity.ok(mainService.getAllPostListHot(page));
   }
+
+  @ApiOperation("메인 페이지 - 검색")
+  @GetMapping("/search")
+  public ResponseEntity<BlogPostList> mainPageSearch(
+      @RequestParam(required = false, defaultValue = "title") String type,
+      @RequestParam(value = "q", required = false, defaultValue = "") String query,
+      @RequestParam(value = "p", required = false, defaultValue = "1") int page) {
+
+    if (!StringUtils.hasText(query)) {
+      return ResponseEntity.ok(mainService.getAllPostListHot(page));
+    }
+
+    if (type.equals("title")) {
+      return ResponseEntity.ok(mainService.searchAllPostByTitleOrIntroduction(query, page));
+    }
+
+    if (type.equals("content")) {
+      return ResponseEntity.ok(mainService.searchAllPostByContent(query, page));
+    }
+
+    if (type.equals("tag")) {
+      return ResponseEntity.ok(mainService.searchAllPostByTag(query, page));
+    }
+
+    //type이 일치하지 않을 떄
+    return ResponseEntity.ok(mainService.getAllPostListHot(page));
+  }
+
 }

--- a/src/main/java/com/blog/som/domain/main/service/ElasticsearchMainService.java
+++ b/src/main/java/com/blog/som/domain/main/service/ElasticsearchMainService.java
@@ -1,0 +1,44 @@
+package com.blog.som.domain.main.service;
+
+import com.blog.som.domain.blog.dto.BlogPostDto;
+import com.blog.som.domain.blog.dto.BlogPostList;
+import com.blog.som.domain.post.elasticsearch.document.PostDocument;
+import com.blog.som.domain.post.elasticsearch.repository.ElasticsearchPostRepository;
+import com.blog.som.global.constant.NumberConstant;
+import com.blog.som.global.constant.SearchConstant;
+import com.blog.som.global.dto.PageDto;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ElasticsearchMainService implements MainService{
+
+  private final ElasticsearchPostRepository elasticsearchPostRepository;
+
+
+  @Override
+  public BlogPostList getMainPageList(String sort, int page) {
+
+    String sortBy = SearchConstant.VIEWS;
+
+    if(sort.equals("latest")){
+      sortBy = SearchConstant.REGISTERED_AT;
+    }
+
+    PageRequest pageRequest =
+        PageRequest.of(page - 1, NumberConstant.DEFAULT_PAGE_SIZE, Sort.by(sortBy).descending());
+
+    Page<PostDocument> findPage = elasticsearchPostRepository.findAll(pageRequest);
+
+    List<BlogPostDto> blogPostDtoList = findPage.getContent().stream().map(BlogPostDto::fromDocument).toList();
+
+    return new BlogPostList(PageDto.fromPostDocumentPage(findPage), blogPostDtoList);
+  }
+}

--- a/src/main/java/com/blog/som/domain/main/service/MainService.java
+++ b/src/main/java/com/blog/som/domain/main/service/MainService.java
@@ -1,0 +1,8 @@
+package com.blog.som.domain.main.service;
+
+import com.blog.som.domain.blog.dto.BlogPostList;
+
+public interface MainService {
+
+  BlogPostList getMainPageList(String sort, int page);
+}

--- a/src/main/java/com/blog/som/domain/main/service/MainService.java
+++ b/src/main/java/com/blog/som/domain/main/service/MainService.java
@@ -4,5 +4,13 @@ import com.blog.som.domain.blog.dto.BlogPostList;
 
 public interface MainService {
 
-  BlogPostList getMainPageList(String sort, int page);
+  BlogPostList getAllPostListHot(int page);
+
+  BlogPostList getAllPostListLatest(int page);
+
+  BlogPostList searchAllPostByTitleOrIntroduction(String query, int page);
+
+  BlogPostList searchAllPostByContent(String query, int page);
+
+  BlogPostList searchAllPostByTag(String query, int page);
 }

--- a/src/main/java/com/blog/som/domain/post/elasticsearch/repository/ElasticsearchPostRepository.java
+++ b/src/main/java/com/blog/som/domain/post/elasticsearch/repository/ElasticsearchPostRepository.java
@@ -1,7 +1,6 @@
 package com.blog.som.domain.post.elasticsearch.repository;
 
 import com.blog.som.domain.post.elasticsearch.document.PostDocument;
-import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.annotations.Query;
@@ -17,6 +16,8 @@ public interface ElasticsearchPostRepository extends ElasticsearchRepository<Pos
 
   @Query("{\"bool\": {\"must\": [{\"match\": {\"account_name\": \"?0\"}}, {\"match\": {\"tags\": \"?1\"}}]}}")
   Page<PostDocument> findByAccountNameAndTagsContaining(String accountName, String tagName, Pageable pageable);
+
+  Page<PostDocument> findAll(Pageable pageable);
 
   //단어가 일치하는 것을 찾는 쿼리
   @Query("{\"bool\": {\"must\": ["

--- a/src/main/java/com/blog/som/domain/post/elasticsearch/repository/ElasticsearchPostRepository.java
+++ b/src/main/java/com/blog/som/domain/post/elasticsearch/repository/ElasticsearchPostRepository.java
@@ -19,13 +19,12 @@ public interface ElasticsearchPostRepository extends ElasticsearchRepository<Pos
 
   Page<PostDocument> findAll(Pageable pageable);
 
-  //단어가 일치하는 것을 찾는 쿼리
-  @Query("{\"bool\": {\"must\": ["
-      + "{\"match\": {\"account_name\": \"?0\"}}, "
-      + "{\"bool\": {\"should\": ["
-      + "{\"match_phrase\": {\"title\": \"?1\"}}, "
-      + "{\"match_phrase\": {\"introduction\": \"?1\"}}"
-      + "]}}"
-      + "]}}")
-  Page<PostDocument> findByAccountNameAndTitleOrIntroductionContaining(String accountName, String query, Pageable pageable);
+  Page<PostDocument> findByTitleContainingOrIntroductionContaining(String title, String introduction, Pageable pageable);
+
+  Page<PostDocument> findByContentContaining(String query, Pageable pageable);
+
+  //정확히 일치하는 경우만 반환
+  @Query("{\"bool\": {\"must\": [{\"match\": {\"tags\": \"?0\"}}]}}")
+  Page<PostDocument> findByTagsContaining(String query, Pageable pageable);
+
 }

--- a/src/main/java/com/blog/som/domain/post/elasticsearch/repository/ElasticsearchPostRepository.java
+++ b/src/main/java/com/blog/som/domain/post/elasticsearch/repository/ElasticsearchPostRepository.java
@@ -14,8 +14,12 @@ public interface ElasticsearchPostRepository extends ElasticsearchRepository<Pos
 
   void deleteByPostId(Long postId);
 
+  //정확히 일치하는 경우만 반환
   @Query("{\"bool\": {\"must\": [{\"match\": {\"account_name\": \"?0\"}}, {\"match\": {\"tags\": \"?1\"}}]}}")
   Page<PostDocument> findByAccountNameAndTagsContaining(String accountName, String tagName, Pageable pageable);
+
+  Page<PostDocument> findByAccountNameAndTitleContainingOrIntroductionContaining(
+      String accountName, String title, String introduction, Pageable pageable);
 
   Page<PostDocument> findAll(Pageable pageable);
 

--- a/src/main/java/com/blog/som/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/blog/som/domain/post/repository/PostRepository.java
@@ -14,4 +14,6 @@ public interface PostRepository extends JpaRepository<PostEntity, Long> {
 
   Page<PostEntity> findByMemberAndTitleContainingOrIntroductionContaining(
       MemberEntity member, String title, String introduction, Pageable pageable);
+
+  Page<PostEntity> findByTitleContainingOrIntroductionContaining(String title, String introduction, Pageable pageable);
 }

--- a/src/test/java/com/blog/som/domain/blog/service/ElasticsearchBlogServiceTest.java
+++ b/src/test/java/com/blog/som/domain/blog/service/ElasticsearchBlogServiceTest.java
@@ -46,8 +46,6 @@ class ElasticsearchBlogServiceTest {
   @Mock
   private MemberRepository memberRepository;
   @Mock
-  private PostRepository postRepository;
-  @Mock
   private FollowService followService;
   @Mock
   private ElasticsearchPostRepository elasticSearchPostRepository;

--- a/src/test/java/com/blog/som/domain/main/service/ElasticsearchMainServiceTest.java
+++ b/src/test/java/com/blog/som/domain/main/service/ElasticsearchMainServiceTest.java
@@ -1,0 +1,179 @@
+package com.blog.som.domain.main.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.when;
+
+import com.blog.som.EntityCreator;
+import com.blog.som.domain.blog.dto.BlogPostDto;
+import com.blog.som.domain.blog.dto.BlogPostList;
+import com.blog.som.domain.member.entity.MemberEntity;
+import com.blog.som.domain.post.elasticsearch.document.PostDocument;
+import com.blog.som.domain.post.elasticsearch.repository.ElasticsearchPostRepository;
+import com.blog.som.global.constant.NumberConstant;
+import com.blog.som.global.constant.SearchConstant;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+
+@Slf4j
+@ExtendWith(MockitoExtension.class)
+class ElasticsearchMainServiceTest {
+
+  @Mock
+  private ElasticsearchPostRepository elasticSearchPostRepository;
+
+  @InjectMocks
+  private ElasticsearchMainService mainService;
+
+  private MemberEntity member;
+
+  private List<PostDocument> getPostDocumentList() {
+    member = EntityCreator.createMember(1L);
+    List<PostDocument> postDocumentList = new ArrayList<>();
+
+    for (int i = 1; i <= 5; i++) {
+      postDocumentList.add(EntityCreator.createPostDocument(EntityCreator.createPost(100L + i, member)));
+    }
+    return postDocumentList;
+  }
+
+  private PageRequest getPageDefaultRequest(int page) {
+    return PageRequest.of(page - 1, NumberConstant.DEFAULT_PAGE_SIZE, Sort.by(SearchConstant.VIEWS).descending());
+  }
+
+  @Test
+  @DisplayName("전체 글 조회 - hot")
+  void getAllPostListHot() {
+    List<PostDocument> postDocumentList = this.getPostDocumentList();
+
+    int page = 1;
+    PageRequest pageRequest = getPageDefaultRequest(page);
+
+    //given
+    when(elasticSearchPostRepository.findAll(pageRequest))
+        .thenReturn(new PageImpl<>(postDocumentList));
+
+    //when
+    BlogPostList result = mainService.getAllPostListHot(page);
+
+    //then
+    for (BlogPostDto bp : result.getPostList()) {
+      assertThat(bp.getMemberId()).isEqualTo(member.getMemberId());
+      assertThat(bp.getAccountName()).isEqualTo(member.getAccountName());
+    }
+    assertThat(result.getPageDto().getCurrentPage()).isEqualTo(1);
+    assertThat(result.getPageDto().getTotalElement()).isEqualTo(5);
+  }
+
+  @Test
+  @DisplayName("전체 글 조회 - latest")
+  void getAllPostListLatest() {
+    List<PostDocument> postDocumentList = this.getPostDocumentList();
+
+    int page = 1;
+    PageRequest pageRequest = PageRequest.of(page - 1,
+        NumberConstant.DEFAULT_PAGE_SIZE, Sort.by(SearchConstant.REGISTERED_AT).descending());
+
+    //given
+    when(elasticSearchPostRepository.findAll(pageRequest))
+        .thenReturn(new PageImpl<>(postDocumentList));
+
+    //when
+    BlogPostList result = mainService.getAllPostListLatest(page);
+
+    //then
+    for (BlogPostDto bp : result.getPostList()) {
+      assertThat(bp.getMemberId()).isEqualTo(member.getMemberId());
+      assertThat(bp.getAccountName()).isEqualTo(member.getAccountName());
+    }
+    assertThat(result.getPageDto().getCurrentPage()).isEqualTo(1);
+    assertThat(result.getPageDto().getTotalElement()).isEqualTo(5);
+  }
+
+  @Test
+  @DisplayName("전체 글 검색 - title 또는 introduction")
+  void searchAllPostByTitleOrIntroduction() {
+    List<PostDocument> postDocumentList = this.getPostDocumentList();
+
+    int page = 1;
+    PageRequest pageRequest = getPageDefaultRequest(page);
+    String query = "test";
+
+    //given
+    when(elasticSearchPostRepository.
+        findByTitleContainingOrIntroductionContaining(query, query, pageRequest))
+        .thenReturn(new PageImpl<>(postDocumentList));
+
+    //when
+    BlogPostList result = mainService.searchAllPostByTitleOrIntroduction(query, page);
+
+    //then
+    for (BlogPostDto bp : result.getPostList()) {
+      assertThat(bp.getMemberId()).isEqualTo(member.getMemberId());
+      assertThat(bp.getAccountName()).isEqualTo(member.getAccountName());
+    }
+    assertThat(result.getPageDto().getCurrentPage()).isEqualTo(1);
+    assertThat(result.getPageDto().getTotalElement()).isEqualTo(5);
+  }
+
+  @Test
+  @DisplayName("전체 글 검색 - content")
+  void searchAllPostByContent() {
+    List<PostDocument> postDocumentList = this.getPostDocumentList();
+
+    int page = 1;
+    PageRequest pageRequest = getPageDefaultRequest(page);
+    String query = "test";
+
+    //given
+    when(elasticSearchPostRepository
+        .findByContentContaining(query, pageRequest))
+        .thenReturn(new PageImpl<>(postDocumentList));
+
+    //when
+    BlogPostList result = mainService.searchAllPostByContent(query, page);
+
+    //then
+    for (BlogPostDto bp : result.getPostList()) {
+      assertThat(bp.getMemberId()).isEqualTo(member.getMemberId());
+      assertThat(bp.getAccountName()).isEqualTo(member.getAccountName());
+    }
+    assertThat(result.getPageDto().getCurrentPage()).isEqualTo(1);
+    assertThat(result.getPageDto().getTotalElement()).isEqualTo(5);
+  }
+
+  @Test
+  @DisplayName("전체 글 검색 - tag")
+  void searchAllPostByTag() {
+    List<PostDocument> postDocumentList = this.getPostDocumentList();
+
+    int page = 1;
+    PageRequest pageRequest = getPageDefaultRequest(page);
+    String query = "test";
+
+    //given
+    when(elasticSearchPostRepository
+        .findByTagsContaining(query, pageRequest))
+        .thenReturn(new PageImpl<>(postDocumentList));
+
+    //when
+    BlogPostList result = mainService.searchAllPostByTag(query, page);
+
+    //then
+    for (BlogPostDto bp : result.getPostList()) {
+      assertThat(bp.getMemberId()).isEqualTo(member.getMemberId());
+      assertThat(bp.getAccountName()).isEqualTo(member.getAccountName());
+    }
+    assertThat(result.getPageDto().getCurrentPage()).isEqualTo(1);
+    assertThat(result.getPageDto().getTotalElement()).isEqualTo(5);
+  }
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요.  -->
### [SOM 메인 페이지 조회 API]
- `GET /main?sort=xxx`
- `sort=hot`(default) : 조회수 순을 조회
- `sort=latest` : 최신 순 조회

### [SOM 메인 페이지 검색 API]
- `GET /search?type=xxx&q=xxx&p=xxx`
- type : `title`, `content`, `tag`
- 검색어 q
    - `title`(default) : 제목 또는 소개 검색
    - `content` : 내용 검색
    - `tag` : 태그 검색

### [검증 로직 추가]
- PathVariable로 들어온 `accountName`이 존재하는지 검증하는 메서드 추가

---

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 

