### PR TITLE
Feat : 프로필 사진 수정, 좋아요, 댓글 작성 시 Entity, Document 수정 로직 구현

### DIFF
--- a/src/main/java/com/blog/som/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/blog/som/domain/comment/controller/CommentController.java
@@ -4,6 +4,7 @@ import com.blog.som.domain.comment.dto.CommentDto;
 import com.blog.som.domain.comment.dto.CommentInput;
 import com.blog.som.domain.comment.service.CommentService;
 import com.blog.som.domain.member.security.userdetails.LoginMember;
+import com.blog.som.domain.post.mongo.service.MongoPostService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import java.util.List;
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class CommentController {
 
   private final CommentService commentService;
+  private final MongoPostService mongoPostService;
 
   @ApiOperation("댓글 작성")
   @PreAuthorize("hasAnyRole('ROLE_USER')")
@@ -36,6 +38,8 @@ public class CommentController {
       @AuthenticationPrincipal LoginMember loginMember) {
 
     CommentDto result = commentService.writeComment(postId, loginMember.getMemberId(), input.getContent());
+
+    mongoPostService.updatePostDocumentComments(true, postId);
 
     return ResponseEntity.ok(result);
   }
@@ -69,6 +73,8 @@ public class CommentController {
       @AuthenticationPrincipal LoginMember loginMember) {
 
     CommentDto result = commentService.deleteComment(commentId, loginMember.getMemberId());
+
+    mongoPostService.updatePostDocumentComments(false, result.getPostId());
 
     return ResponseEntity.ok(result);
   }

--- a/src/main/java/com/blog/som/domain/comment/dto/CommentDto.java
+++ b/src/main/java/com/blog/som/domain/comment/dto/CommentDto.java
@@ -14,7 +14,8 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class CommentDto {
+public class
+CommentDto {
   private Long commentId;
 
   private String content;

--- a/src/main/java/com/blog/som/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/blog/som/domain/comment/service/CommentServiceImpl.java
@@ -36,6 +36,9 @@ public class CommentServiceImpl implements CommentService {
 
     CommentEntity saved = commentRepository.save(new CommentEntity(member, post, commentString));
 
+    post.addComments();
+    postRepository.save(post);
+
     return CommentDto.fromEntity(saved);
   }
 
@@ -75,6 +78,11 @@ public class CommentServiceImpl implements CommentService {
     if (comment.getMember().getMemberId().equals(loginMemberId) ||
         comment.getPost().getMember().getMemberId().equals(loginMemberId)) {
       commentRepository.delete(comment);
+
+      PostEntity post = comment.getPost();
+      post.minusComments();
+      postRepository.save(post);
+
       return CommentDto.fromEntity(comment);
     }
 

--- a/src/main/java/com/blog/som/domain/likes/controller/LikesController.java
+++ b/src/main/java/com/blog/som/domain/likes/controller/LikesController.java
@@ -4,6 +4,7 @@ import com.blog.som.domain.likes.dto.LikesResponse.MemberLikesPost;
 import com.blog.som.domain.likes.dto.LikesResponse.ToggleResult;
 import com.blog.som.domain.likes.service.LikesService;
 import com.blog.som.domain.member.security.userdetails.LoginMember;
+import com.blog.som.domain.post.mongo.service.MongoPostService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class LikesController {
 
   private final LikesService likesService;
+  private final MongoPostService mongoPostService;
 
   @ApiOperation(value = "좋아요 누르기 / 누르기 취소", notes = "토글 형식으로 좋아요 누르기 / 취소가 반복된다.")
   @PreAuthorize("hasAnyRole('ROLE_USER')")
@@ -31,6 +33,8 @@ public class LikesController {
       @AuthenticationPrincipal LoginMember loginMember) {
 
     ToggleResult toggleResult = likesService.toggleLikes(postId, loginMember.getMemberId());
+
+    mongoPostService.updatePostDocumentLikes(toggleResult.isResult(), postId);
 
     return ResponseEntity.ok(toggleResult);
   }

--- a/src/main/java/com/blog/som/domain/likes/dto/LikesResponse.java
+++ b/src/main/java/com/blog/som/domain/likes/dto/LikesResponse.java
@@ -13,11 +13,13 @@ public class LikesResponse {
   @Getter
   @Setter
   public static class ToggleResult{
+    private boolean result;
     private Long memberId;
     private Long postId;
     private String message;
 
     public ToggleResult(boolean result, Long memberId, Long postId) {
+      this.result = result;
       if(result){
         this.memberId = memberId;
         this.postId = postId;

--- a/src/main/java/com/blog/som/domain/likes/service/LikesServiceImpl.java
+++ b/src/main/java/com/blog/som/domain/likes/service/LikesServiceImpl.java
@@ -24,7 +24,6 @@ public class LikesServiceImpl implements LikesService {
   private final PostRepository postRepository;
   private final MemberRepository memberRepository;
   private final LikesRepository likesRepository;
-  private final MongoPostService mongoPostService;
 
   @Override
   public LikesResponse.ToggleResult toggleLikes(Long postId, Long loginMemberId) {
@@ -41,16 +40,12 @@ public class LikesServiceImpl implements LikesService {
       post.addLikes();
       postRepository.save(post);
 
-      mongoPostService.updatePostDocumentLikes(true, postId);
-
       return new LikesResponse.ToggleResult(true, loginMemberId, postId);
     }
     likesRepository.delete(optionalLikes.get());
 
     post.minusLikes();
     postRepository.save(post);
-
-    mongoPostService.updatePostDocumentLikes(false, postId);
 
     return new LikesResponse.ToggleResult(false, loginMemberId, postId);
   }

--- a/src/main/java/com/blog/som/domain/post/entity/PostEntity.java
+++ b/src/main/java/com/blog/som/domain/post/entity/PostEntity.java
@@ -71,6 +71,17 @@ public class PostEntity {
     this.views += 1;
   }
 
+  public void addLikes(){
+    this.likes += 1;
+  }
+
+  public void minusLikes(){
+    if(likes > 0){
+      this.likes -= 1;
+    }
+  }
+
+
   public void editPost(PostEditRequest request){
     this.title = request.getTitle();
     this.content = request.getContent();

--- a/src/main/java/com/blog/som/domain/post/entity/PostEntity.java
+++ b/src/main/java/com/blog/som/domain/post/entity/PostEntity.java
@@ -81,6 +81,15 @@ public class PostEntity {
     }
   }
 
+  public void addComments() {
+    this.comments += 1;
+  }
+
+  public void minusComments(){
+    if(this.comments > 0){
+      this.comments -= 1;
+    }
+  }
 
   public void editPost(PostEditRequest request){
     this.title = request.getTitle();

--- a/src/main/java/com/blog/som/domain/post/mongo/document/PostDocument.java
+++ b/src/main/java/com/blog/som/domain/post/mongo/document/PostDocument.java
@@ -67,6 +67,12 @@ public class PostDocument {
     this.likes += 1;
   }
 
+  public void minusLikes(){
+    if(this.likes > 0){
+      this.likes -= 1;
+    }
+  }
+
   public static PostDocument fromEntity(PostEntity postEntity, List<String> tags) {
     return PostDocument.builder()
         .postId(postEntity.getPostId())

--- a/src/main/java/com/blog/som/domain/post/mongo/document/PostDocument.java
+++ b/src/main/java/com/blog/som/domain/post/mongo/document/PostDocument.java
@@ -73,6 +73,16 @@ public class PostDocument {
     }
   }
 
+  public void addComments() {
+    this.comments += 1;
+  }
+
+  public void minusComments(){
+    if(this.comments > 0){
+      this.comments -= 1;
+    }
+  }
+
   public static PostDocument fromEntity(PostEntity postEntity, List<String> tags) {
     return PostDocument.builder()
         .postId(postEntity.getPostId())

--- a/src/main/java/com/blog/som/domain/post/mongo/service/MongoPostService.java
+++ b/src/main/java/com/blog/som/domain/post/mongo/service/MongoPostService.java
@@ -55,4 +55,16 @@ public class MongoPostService {
     mongoPostRepository.save(postDocument);
   }
 
+  public void updatePostDocumentComments(boolean result, Long postId){
+    PostDocument postDocument = mongoPostRepository.findByPostId(postId)
+        .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
+
+    if(result){
+      postDocument.addComments();
+    }else{
+      postDocument.minusComments();
+    }
+    mongoPostRepository.save(postDocument);
+  }
+
 }

--- a/src/main/java/com/blog/som/domain/post/mongo/service/MongoPostService.java
+++ b/src/main/java/com/blog/som/domain/post/mongo/service/MongoPostService.java
@@ -2,6 +2,8 @@ package com.blog.som.domain.post.mongo.service;
 
 import com.blog.som.domain.post.mongo.document.PostDocument;
 import com.blog.som.domain.post.mongo.respository.MongoPostRepository;
+import com.blog.som.global.exception.ErrorCode;
+import com.blog.som.global.exception.custom.PostException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -39,6 +41,18 @@ public class MongoPostService {
       documentPage = mongoPostRepository.findByAccountName(accountName, PageRequest.of(page, pageSize));
     }
     log.info("[Elasticsearch PostDocument update profile_image] total amount={}", amount);
+  }
+
+  public void updatePostDocumentLikes(boolean result, Long postId){
+    PostDocument postDocument = mongoPostRepository.findByPostId(postId)
+        .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
+
+    if(result){
+      postDocument.addLikes();
+    }else{
+      postDocument.minusLikes();
+    }
+    mongoPostRepository.save(postDocument);
   }
 
 }

--- a/src/main/java/com/blog/som/domain/post/mongo/service/MongoPostService.java
+++ b/src/main/java/com/blog/som/domain/post/mongo/service/MongoPostService.java
@@ -1,0 +1,44 @@
+package com.blog.som.domain.post.mongo.service;
+
+import com.blog.som.domain.post.mongo.document.PostDocument;
+import com.blog.som.domain.post.mongo.respository.MongoPostRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class MongoPostService {
+
+  private final MongoPostRepository mongoPostRepository;
+
+  @Async
+  public void updatePostDocumentProfileImage(String accountName, String profileImage) {
+    int page = 0;
+    int pageSize = 100;
+    int amount = 0;
+
+    Page<PostDocument> documentPage = mongoPostRepository.findByAccountName(accountName,
+        PageRequest.of(page, pageSize));
+
+    while (documentPage.getNumberOfElements() != 0) {
+      List<PostDocument> list = documentPage.getContent();
+      amount += list.size();
+      for (PostDocument postDocument : list) {
+        postDocument.setProfileImage(profileImage);
+      }
+      mongoPostRepository.saveAll(list);
+      log.info("page={}, accumulate={}", page, amount);
+
+      page++;
+      documentPage = mongoPostRepository.findByAccountName(accountName, PageRequest.of(page, pageSize));
+    }
+    log.info("[Elasticsearch PostDocument update profile_image] total amount={}", amount);
+  }
+
+}

--- a/src/test/java/com/blog/som/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/blog/som/domain/member/service/MemberServiceTest.java
@@ -17,6 +17,7 @@ import com.blog.som.domain.member.dto.MemberRegister.Request;
 import com.blog.som.domain.member.dto.RegisterEmailInput;
 import com.blog.som.domain.member.entity.MemberEntity;
 import com.blog.som.domain.member.repository.MemberRepository;
+import com.blog.som.domain.post.mongo.service.MongoPostService;
 import com.blog.som.global.components.mail.MailSender;
 import com.blog.som.global.components.mail.SendMailDto;
 import com.blog.som.global.util.PasswordUtils;
@@ -51,6 +52,8 @@ class MemberServiceTest {
   private MailSender mailSender;
   @Mock
   private S3ImageService s3ImageService;
+  @Mock
+  private MongoPostService mongoPostService;
 
   @InjectMocks
   private MemberServiceImpl memberService;


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요.  -->
### [회원 프로필 사진 수정]
- PostDocument의 `profileImage` 수정

### [좋아요, 댓글 작성 시 PostDocument, PostEntity 수정]
- 좋아요 시 : `likes += 1`
- 좋아요 취소 시 : 'likes -= 1`
- 댓글 작성 시 : `comments += 1`
- 댓글 삭제 시 : `comments -= 1`
- 
---

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 

