### PR TITLE
Feat : 알림 API

### DIFF
--- a/src/main/java/com/blog/som/domain/follow/service/FollowServiceImpl.java
+++ b/src/main/java/com/blog/som/domain/follow/service/FollowServiceImpl.java
@@ -6,6 +6,8 @@ import com.blog.som.domain.follow.entity.FollowEntity;
 import com.blog.som.domain.follow.repository.FollowRepository;
 import com.blog.som.domain.member.entity.MemberEntity;
 import com.blog.som.domain.member.repository.MemberRepository;
+import com.blog.som.domain.notification.dto.NotificationCreateDto;
+import com.blog.som.domain.notification.service.NotificationService;
 import com.blog.som.global.exception.ErrorCode;
 import com.blog.som.global.exception.custom.BlogException;
 import com.blog.som.global.exception.custom.FollowException;
@@ -23,6 +25,7 @@ public class FollowServiceImpl implements FollowService{
 
   private final FollowRepository followRepository;
   private final MemberRepository memberRepository;
+  private final NotificationService notificationService;
 
   @Override
   public FollowDto doFollow(Long fromMemberId, String blogAccountName) {
@@ -41,6 +44,9 @@ public class FollowServiceImpl implements FollowService{
 
     memberRepository.save(fromMember);
     memberRepository.save(toMember);
+
+    notificationService.notify(toMember, fromMember,
+        NotificationCreateDto.follow(fromMember, saved.getFollowId()));
 
     return FollowDto.fromEntity(saved);
   }

--- a/src/main/java/com/blog/som/domain/likes/dto/LikesResponse.java
+++ b/src/main/java/com/blog/som/domain/likes/dto/LikesResponse.java
@@ -2,7 +2,10 @@ package com.blog.som.domain.likes.dto;
 
 import com.blog.som.domain.likes.constant.LikesConstant;
 import com.blog.som.domain.likes.type.LikesStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 
@@ -10,30 +13,46 @@ public class LikesResponse {
 
   @Getter
   @Setter
+  @AllArgsConstructor
+  @NoArgsConstructor
+  @Builder
   public static class ToggleResult {
 
-    private boolean result;
+    private LikesStatus likesStatus;
     private Long memberId;
     private Long postId;
     private String message;
 
     public ToggleResult(boolean result, Long memberId, Long postId) {
-      this.result = result;
+
       if (result) {
+        this.likesStatus = LikesStatus.LIKES;
         this.memberId = memberId;
         this.postId = postId;
         this.message = LikesConstant.LIKES_COMPLETE;
       } else {
+        this.likesStatus = LikesStatus.NOT_LIKES;
         this.memberId = memberId;
         this.postId = postId;
         this.message = LikesConstant.LIKES_CANCELED;
       }
+    }
 
+    public static ToggleResult unAuth() {
+      return ToggleResult.builder()
+          .likesStatus(LikesStatus.NOT_LOGGED_IN)
+          .memberId(0L)
+          .postId(0L)
+          .message("")
+          .build();
     }
   }
 
   @Getter
   @Setter
+  @AllArgsConstructor
+  @NoArgsConstructor
+  @Builder
   public static class MemberLikesPost {
 
     private LikesStatus likesStatus;
@@ -54,6 +73,15 @@ public class LikesResponse {
         this.message = LikesConstant.LIKES_DOESNT_EXISTS;
       }
 
+    }
+
+    public static MemberLikesPost unAuth() {
+      return MemberLikesPost.builder()
+          .likesStatus(LikesStatus.NOT_LOGGED_IN)
+          .memberId(0L)
+          .postId(0L)
+          .message("")
+          .build();
     }
   }
 

--- a/src/main/java/com/blog/som/domain/likes/service/LikesServiceImpl.java
+++ b/src/main/java/com/blog/som/domain/likes/service/LikesServiceImpl.java
@@ -5,6 +5,8 @@ import com.blog.som.domain.likes.entity.LikesEntity;
 import com.blog.som.domain.likes.repository.LikesRepository;
 import com.blog.som.domain.member.entity.MemberEntity;
 import com.blog.som.domain.member.repository.MemberRepository;
+import com.blog.som.domain.notification.dto.NotificationCreateDto;
+import com.blog.som.domain.notification.service.NotificationService;
 import com.blog.som.domain.post.entity.PostEntity;
 import com.blog.som.domain.post.mongo.service.MongoPostService;
 import com.blog.som.domain.post.repository.PostRepository;
@@ -24,6 +26,7 @@ public class LikesServiceImpl implements LikesService {
   private final PostRepository postRepository;
   private final MemberRepository memberRepository;
   private final LikesRepository likesRepository;
+  private final NotificationService notificationService;
 
   @Override
   public LikesResponse.ToggleResult toggleLikes(Long postId, Long loginMemberId) {
@@ -40,8 +43,12 @@ public class LikesServiceImpl implements LikesService {
       post.addLikes();
       postRepository.save(post);
 
+      notificationService.notify(post.getMember(), member,
+          NotificationCreateDto.likes(member, post));
+
       return new LikesResponse.ToggleResult(true, loginMemberId, postId);
     }
+
     likesRepository.delete(optionalLikes.get());
 
     post.minusLikes();

--- a/src/main/java/com/blog/som/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/blog/som/domain/notification/controller/NotificationController.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -42,6 +43,16 @@ public class NotificationController {
         notificationService.getNotifications(loginMember.getMemberId());
 
     return ResponseEntity.ok(notifications);
+  }
+
+  @ApiOperation("안읽은 알림 존재 여부")
+  @PreAuthorize("hasAnyRole('ROLE_USER')")
+  @GetMapping("/notification/unread")
+  public ResponseEntity<Boolean> unreadNotificationExists(
+      @AuthenticationPrincipal LoginMember loginMember) {
+
+    boolean result = notificationService.checkUnreadNotification(loginMember.getMemberId());
+    return ResponseEntity.ok(result);
   }
 
 }

--- a/src/main/java/com/blog/som/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/blog/som/domain/notification/controller/NotificationController.java
@@ -1,23 +1,26 @@
 package com.blog.som.domain.notification.controller;
 
 import com.blog.som.domain.member.security.userdetails.LoginMember;
+import com.blog.som.domain.notification.dto.NotificationDto;
 import com.blog.som.domain.notification.service.NotificationService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import java.util.List;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-@Api(tags = "알림 SSE 관련")
+@Api(tags = "알림(Notification)")
 @Slf4j
 @RequiredArgsConstructor
 @RestController
-public class NotificationSseController {
+public class NotificationController {
 
   private final NotificationService notificationService;
 
@@ -28,6 +31,17 @@ public class NotificationSseController {
     response.setCharacterEncoding("UTF-8");
 
     return notificationService.subscribe(loginMember.getMemberId());
+  }
+
+  @ApiOperation("알림 리스트 보기")
+  @GetMapping("/notifications")
+  public ResponseEntity<List<NotificationDto>> notificationList(
+      @AuthenticationPrincipal LoginMember loginMember) {
+
+    List<NotificationDto> notifications =
+        notificationService.getNotifications(loginMember.getMemberId());
+
+    return ResponseEntity.ok(notifications);
   }
 
 }

--- a/src/main/java/com/blog/som/domain/notification/controller/NotificationSseController.java
+++ b/src/main/java/com/blog/som/domain/notification/controller/NotificationSseController.java
@@ -1,0 +1,33 @@
+package com.blog.som.domain.notification.controller;
+
+import com.blog.som.domain.member.security.userdetails.LoginMember;
+import com.blog.som.domain.notification.service.NotificationService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Api(tags = "알림 SSE 관련")
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+public class NotificationSseController {
+
+  private final NotificationService notificationService;
+
+  @ApiOperation(value = "구독을 시작하기 위한 메서드")
+  @GetMapping(value = "/sse/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+  public SseEmitter subscribe(@AuthenticationPrincipal LoginMember loginMember,
+      HttpServletResponse response) {
+    response.setCharacterEncoding("UTF-8");
+
+    return notificationService.subscribe(loginMember.getMemberId());
+  }
+
+}

--- a/src/main/java/com/blog/som/domain/notification/dto/NotificationCreateDto.java
+++ b/src/main/java/com/blog/som/domain/notification/dto/NotificationCreateDto.java
@@ -1,5 +1,7 @@
 package com.blog.som.domain.notification.dto;
 
+import com.blog.som.domain.member.entity.MemberEntity;
+import com.blog.som.domain.notification.entity.NotificationEntity;
 import com.blog.som.domain.notification.type.NotificationSituation;
 
 import lombok.AllArgsConstructor;
@@ -22,6 +24,20 @@ public class NotificationCreateDto {
   private String message2;
   private String url;
 
+  public static NotificationEntity toEntity(
+      MemberEntity member, MemberEntity writer, NotificationCreateDto notificationCreateDto){
+    return NotificationEntity.builder()
+        .member(member)
+        .writer(writer)
+        .notificationSituation(notificationCreateDto.getNotificationSituation())
+        .targetEntityId(notificationCreateDto.getTargetEntityId())
+        .title(notificationCreateDto.getTitle())
+        .message1(notificationCreateDto.getMessage1())
+        .message2(notificationCreateDto.getMessage2())
+        .url(notificationCreateDto.getUrl())
+        .build();
+  }
+
   public static NotificationCreateDto comment(){
     return NotificationCreateDto.builder()
         .build();
@@ -36,5 +52,7 @@ public class NotificationCreateDto {
     return NotificationCreateDto.builder()
         .build();
   }
+
+
 
 }

--- a/src/main/java/com/blog/som/domain/notification/dto/NotificationCreateDto.java
+++ b/src/main/java/com/blog/som/domain/notification/dto/NotificationCreateDto.java
@@ -57,7 +57,7 @@ public class NotificationCreateDto {
   }
 
   public static NotificationCreateDto follow(MemberEntity fromMember, Long followId){
-    String title = fromMember.getNickname() + " 님이 팔로우 하였습니다.";
+    String title = "<strong>" + fromMember.getNickname() + "</strong>" + " 님이 팔로우 하였습니다.";
     String message1 = "[" + fromMember.getBlogName() + "] <- 블로그 방문하기";
     String message2 = "";
     String url = "/blog/" + fromMember.getAccountName();
@@ -73,7 +73,7 @@ public class NotificationCreateDto {
   }
 
   public static NotificationCreateDto likes(MemberEntity fromMember, PostEntity post){
-    String title = fromMember.getNickname() + " 님이 게시글을 좋아합니다.";
+    String title = "<strong>" + fromMember.getNickname() + "</strong>" + " 님이 게시글을 좋아합니다.";
     String message1 = post.getTitle();
     String message2 = "";
     String url = "/blog/" + post.getMember().getAccountName() + "/" + post.getPostId();

--- a/src/main/java/com/blog/som/domain/notification/dto/NotificationCreateDto.java
+++ b/src/main/java/com/blog/som/domain/notification/dto/NotificationCreateDto.java
@@ -1,9 +1,11 @@
 package com.blog.som.domain.notification.dto;
 
+import com.blog.som.domain.comment.entity.CommentEntity;
 import com.blog.som.domain.member.entity.MemberEntity;
 import com.blog.som.domain.notification.entity.NotificationEntity;
 import com.blog.som.domain.notification.type.NotificationSituation;
 
+import com.blog.som.domain.post.entity.PostEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -38,8 +40,19 @@ public class NotificationCreateDto {
         .build();
   }
 
-  public static NotificationCreateDto comment(){
+  public static NotificationCreateDto comment(String writerNickname, PostEntity post, CommentEntity comment){
+    String title = writerNickname + " 님이 댓글을 남겼습니다.";
+    String message1 = comment.getContent();
+    String message2 = post.getTitle();
+    String url = "/post/" + post.getPostId();
+
     return NotificationCreateDto.builder()
+        .notificationSituation(NotificationSituation.COMMENT)
+        .targetEntityId(comment.getCommentId())
+        .title(title)
+        .message1(message1)
+        .message2(message2)
+        .url(url)
         .build();
   }
 

--- a/src/main/java/com/blog/som/domain/notification/dto/NotificationCreateDto.java
+++ b/src/main/java/com/blog/som/domain/notification/dto/NotificationCreateDto.java
@@ -1,0 +1,40 @@
+package com.blog.som.domain.notification.dto;
+
+import com.blog.som.domain.notification.type.NotificationSituation;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class NotificationCreateDto {
+
+  private NotificationSituation notificationSituation;
+  private Long targetEntityId;
+  private String title;
+  private String message1;
+  private String message2;
+  private String url;
+
+  public static NotificationCreateDto comment(){
+    return NotificationCreateDto.builder()
+        .build();
+  }
+
+  public static NotificationCreateDto follow(){
+    return NotificationCreateDto.builder()
+        .build();
+  }
+
+  public static NotificationCreateDto likes(){
+    return NotificationCreateDto.builder()
+        .build();
+  }
+
+}

--- a/src/main/java/com/blog/som/domain/notification/dto/NotificationCreateDto.java
+++ b/src/main/java/com/blog/som/domain/notification/dto/NotificationCreateDto.java
@@ -41,7 +41,7 @@ public class NotificationCreateDto {
   }
 
   public static NotificationCreateDto comment(String writerNickname, PostEntity post, CommentEntity comment){
-    String title = writerNickname + " 님이 댓글을 남겼습니다.";
+    String title = "<strong>" + writerNickname + "</strong>" + "님이 댓글을 남겼습니다.";
     String message1 = comment.getContent();
     String message2 = post.getTitle();
     String url = "/post/" + post.getPostId();
@@ -56,8 +56,19 @@ public class NotificationCreateDto {
         .build();
   }
 
-  public static NotificationCreateDto follow(){
+  public static NotificationCreateDto follow(MemberEntity fromMember, Long followId){
+    String title = fromMember.getNickname() + " 님이 댓글을 남겼습니다.";
+    String message1 = "[" + fromMember.getBlogName() + "] <- 블로그 방문하기";
+    String message2 = "";
+    String url = "/blog/" + fromMember.getAccountName();
+
     return NotificationCreateDto.builder()
+        .notificationSituation(NotificationSituation.FOLLOWED)
+        .targetEntityId(followId)
+        .title(title)
+        .message1(message1)
+        .message2(message2)
+        .url(url)
         .build();
   }
 

--- a/src/main/java/com/blog/som/domain/notification/dto/NotificationCreateDto.java
+++ b/src/main/java/com/blog/som/domain/notification/dto/NotificationCreateDto.java
@@ -44,7 +44,7 @@ public class NotificationCreateDto {
     String title = "<strong>" + writerNickname + "</strong>" + "님이 댓글을 남겼습니다.";
     String message1 = comment.getContent();
     String message2 = post.getTitle();
-    String url = "/post/" + post.getPostId();
+    String url = "/blog/" + post.getMember().getAccountName() + "/" + post.getPostId();
 
     return NotificationCreateDto.builder()
         .notificationSituation(NotificationSituation.COMMENT)
@@ -57,7 +57,7 @@ public class NotificationCreateDto {
   }
 
   public static NotificationCreateDto follow(MemberEntity fromMember, Long followId){
-    String title = fromMember.getNickname() + " 님이 댓글을 남겼습니다.";
+    String title = fromMember.getNickname() + " 님이 팔로우 하였습니다.";
     String message1 = "[" + fromMember.getBlogName() + "] <- 블로그 방문하기";
     String message2 = "";
     String url = "/blog/" + fromMember.getAccountName();
@@ -72,8 +72,19 @@ public class NotificationCreateDto {
         .build();
   }
 
-  public static NotificationCreateDto likes(){
+  public static NotificationCreateDto likes(MemberEntity fromMember, PostEntity post){
+    String title = fromMember.getNickname() + " 님이 게시글을 좋아합니다.";
+    String message1 = post.getTitle();
+    String message2 = "";
+    String url = "/blog/" + post.getMember().getAccountName() + "/" + post.getPostId();
+
     return NotificationCreateDto.builder()
+        .notificationSituation(NotificationSituation.LIKES)
+        .targetEntityId(post.getPostId())
+        .title(title)
+        .message1(message1)
+        .message2(message2)
+        .url(url)
         .build();
   }
 

--- a/src/main/java/com/blog/som/domain/notification/dto/NotificationDto.java
+++ b/src/main/java/com/blog/som/domain/notification/dto/NotificationDto.java
@@ -20,7 +20,9 @@ public class NotificationDto {
 
   private Long memberId;
 
-  private String profileImage;
+  private Long writerId;
+
+  private String writerProfileImage;
 
   private NotificationSituation notificationSituation;
 
@@ -42,9 +44,10 @@ public class NotificationDto {
     return NotificationDto.builder()
         .notificationId(notification.getNotificationId())
         .memberId(notification.getMember().getMemberId())
+        .writerId(notification.getWriter().getMemberId())
+        .writerProfileImage(notification.getWriter().getProfileImage())
         .notificationSituation(notification.getNotificationSituation())
         .targetEntityId(notification.getTargetEntityId())
-        .profileImage(notification.getProfileImage())
         .title(notification.getTitle())
         .message1(notification.getMessage1())
         .message2(notification.getMessage2())

--- a/src/main/java/com/blog/som/domain/notification/dto/NotificationDto.java
+++ b/src/main/java/com/blog/som/domain/notification/dto/NotificationDto.java
@@ -22,6 +22,8 @@ public class NotificationDto {
 
   private Long writerId;
 
+  private String writerAccountName;
+
   private String writerProfileImage;
 
   private NotificationSituation notificationSituation;
@@ -45,6 +47,7 @@ public class NotificationDto {
         .notificationId(notification.getNotificationId())
         .memberId(notification.getMember().getMemberId())
         .writerId(notification.getWriter().getMemberId())
+        .writerAccountName(notification.getWriter().getAccountName())
         .writerProfileImage(notification.getWriter().getProfileImage())
         .notificationSituation(notification.getNotificationSituation())
         .targetEntityId(notification.getTargetEntityId())

--- a/src/main/java/com/blog/som/domain/notification/dto/NotificationDto.java
+++ b/src/main/java/com/blog/som/domain/notification/dto/NotificationDto.java
@@ -1,0 +1,56 @@
+package com.blog.som.domain.notification.dto;
+
+import com.blog.som.domain.notification.entity.NotificationEntity;
+import com.blog.som.domain.notification.type.NotificationSituation;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class NotificationDto {
+
+  private Long notificationId;
+
+  private Long memberId;
+
+  private String profileImage;
+
+  private NotificationSituation notificationSituation;
+
+  private Long targetEntityId;
+
+  private String title;
+
+  private String message1;
+
+  private String message2;
+
+  private String url;
+
+  private LocalDateTime createdAt;
+
+  private LocalDateTime readAt;
+
+  public static NotificationDto fromEntity(NotificationEntity notification){
+    return NotificationDto.builder()
+        .notificationId(notification.getNotificationId())
+        .memberId(notification.getMember().getMemberId())
+        .notificationSituation(notification.getNotificationSituation())
+        .targetEntityId(notification.getTargetEntityId())
+        .profileImage(notification.getProfileImage())
+        .title(notification.getTitle())
+        .message1(notification.getMessage1())
+        .message2(notification.getMessage2())
+        .url(notification.getUrl())
+        .createdAt(notification.getCreatedAt())
+        .readAt(notification.getReadAt())
+        .build();
+  }
+}

--- a/src/main/java/com/blog/som/domain/notification/entity/NotificationEntity.java
+++ b/src/main/java/com/blog/som/domain/notification/entity/NotificationEntity.java
@@ -1,0 +1,93 @@
+package com.blog.som.domain.notification.entity;
+
+import com.blog.som.domain.member.entity.MemberEntity;
+import com.blog.som.domain.notification.type.NotificationSituation;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+@Entity(name = "notification")
+public class NotificationEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "notificationId", nullable = false)
+  private Long notificationId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id", nullable = false)
+  private MemberEntity member;
+
+  @Column(name = "profile_image")
+  private String profileImage;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "notification_situation", nullable = false)
+  private NotificationSituation notificationSituation; //어떤 엔티티에 대한 알림인지 타입
+
+  @Column(name = "target_entity_id", nullable = false)
+  private Long targetEntityId; //type에서 선택된 타겟 엔티티의 id(PK)값
+
+  @Column(name = "title", nullable = false)
+  private String title;
+
+  @Column(name = "message1")
+  private String message1;
+
+  @Column(name = "message2")
+  private String message2;
+
+  @Column(name = "url")
+  private String url;
+
+  @CreatedDate
+  @Column(name = "created_at")
+  private LocalDateTime createdAt;
+
+  @Column(name = "read_at")
+  private LocalDateTime readAt;
+
+  public void readNow(){
+    this.readAt = LocalDateTime.now();
+  }
+
+  @Override
+  public boolean equals(Object object) {
+    if (this == object) {
+      return true;
+    }
+    if (object == null || getClass() != object.getClass()) {
+      return false;
+    }
+    NotificationEntity that = (NotificationEntity) object;
+    return Objects.equals(notificationId, that.notificationId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(notificationId);
+  }
+}

--- a/src/main/java/com/blog/som/domain/notification/entity/NotificationEntity.java
+++ b/src/main/java/com/blog/som/domain/notification/entity/NotificationEntity.java
@@ -43,7 +43,7 @@ public class NotificationEntity {
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "writer_id", nullable = false)
-  private MemberEntity writer; //알림 주인
+  private MemberEntity writer; //알림 생성자
 
   @Enumerated(EnumType.STRING)
   @Column(name = "notification_situation", nullable = false)

--- a/src/main/java/com/blog/som/domain/notification/entity/NotificationEntity.java
+++ b/src/main/java/com/blog/som/domain/notification/entity/NotificationEntity.java
@@ -39,10 +39,11 @@ public class NotificationEntity {
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "member_id", nullable = false)
-  private MemberEntity member;
+  private MemberEntity member; //알림 주인
 
-  @Column(name = "profile_image")
-  private String profileImage;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "writer_id", nullable = false)
+  private MemberEntity writer; //알림 주인
 
   @Enumerated(EnumType.STRING)
   @Column(name = "notification_situation", nullable = false)

--- a/src/main/java/com/blog/som/domain/notification/repository/EmitterRepository.java
+++ b/src/main/java/com/blog/som/domain/notification/repository/EmitterRepository.java
@@ -1,0 +1,25 @@
+package com.blog.som.domain.notification.repository;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Repository
+public class EmitterRepository {
+
+  private final Map<Long, SseEmitter> emitterMap = new ConcurrentHashMap<>();
+
+  public void save(Long id, SseEmitter sseEmitter){
+    emitterMap.put(id, sseEmitter);
+  }
+
+  public void deleteById(Long id){
+    emitterMap.remove(id);
+  }
+
+  public SseEmitter getEmitter(Long id){
+    return emitterMap.get(id);
+  }
+
+}

--- a/src/main/java/com/blog/som/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/blog/som/domain/notification/repository/NotificationRepository.java
@@ -1,10 +1,13 @@
 package com.blog.som.domain.notification.repository;
 
+import com.blog.som.domain.member.entity.MemberEntity;
 import com.blog.som.domain.notification.entity.NotificationEntity;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface NotificationRepository extends JpaRepository<NotificationEntity, Long> {
 
+  List<NotificationEntity> findTop100ByMemberOrderByCreatedAtDesc(MemberEntity member);
 }

--- a/src/main/java/com/blog/som/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/blog/som/domain/notification/repository/NotificationRepository.java
@@ -11,5 +11,7 @@ public interface NotificationRepository extends JpaRepository<NotificationEntity
 
   List<NotificationEntity> findTop100ByMemberOrderByCreatedAtDesc(MemberEntity member);
 
+  List<NotificationEntity> findByMemberAndReadAtIsNull(MemberEntity member);
+
   boolean existsByMemberAndReadAtIsNull(MemberEntity member);
 }

--- a/src/main/java/com/blog/som/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/blog/som/domain/notification/repository/NotificationRepository.java
@@ -10,4 +10,6 @@ import org.springframework.stereotype.Repository;
 public interface NotificationRepository extends JpaRepository<NotificationEntity, Long> {
 
   List<NotificationEntity> findTop100ByMemberOrderByCreatedAtDesc(MemberEntity member);
+
+  boolean existsByMemberAndReadAtIsNull(MemberEntity member);
 }

--- a/src/main/java/com/blog/som/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/blog/som/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,10 @@
+package com.blog.som.domain.notification.repository;
+
+import com.blog.som.domain.notification.entity.NotificationEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<NotificationEntity, Long> {
+
+}

--- a/src/main/java/com/blog/som/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/blog/som/domain/notification/service/NotificationService.java
@@ -14,6 +14,11 @@ public interface NotificationService {
   List<NotificationDto> getNotifications(Long memberId);
 
   /**
+   * 안읽은 알림 여부 확인
+   */
+  boolean checkUnreadNotification(Long memberId);
+
+  /**
    * 서버의 이벤트를 클라이언트에게 보내는 메서드 (실제 알림 발생 시 사용)
    */
   NotificationDto notify(MemberEntity member, MemberEntity writer, NotificationCreateDto notificationCreateDto);
@@ -22,6 +27,5 @@ public interface NotificationService {
    * 클라이언트가 구독을 위해 호출하는 메서드
    */
   SseEmitter subscribe(Long memberId);
-
 
 }

--- a/src/main/java/com/blog/som/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/blog/som/domain/notification/service/NotificationService.java
@@ -1,0 +1,20 @@
+package com.blog.som.domain.notification.service;
+
+import com.blog.som.domain.member.entity.MemberEntity;
+import com.blog.som.domain.notification.dto.NotificationCreateDto;
+import com.blog.som.domain.notification.dto.NotificationDto;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+public interface NotificationService {
+
+  /**
+   * 서버의 이벤트를 클라이언트에게 보내는 메서드 (실제 알림 발생 시 사용)
+   */
+  NotificationDto notify(MemberEntity member, MemberEntity writer, NotificationCreateDto notificationCreateDto);
+
+  /**
+   * 클라이언트가 구독을 위해 호출하는 메서드
+   */
+  SseEmitter subscribe(Long memberId);
+
+}

--- a/src/main/java/com/blog/som/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/blog/som/domain/notification/service/NotificationService.java
@@ -3,9 +3,15 @@ package com.blog.som.domain.notification.service;
 import com.blog.som.domain.member.entity.MemberEntity;
 import com.blog.som.domain.notification.dto.NotificationCreateDto;
 import com.blog.som.domain.notification.dto.NotificationDto;
+import java.util.List;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 public interface NotificationService {
+
+  /**
+   * 알림 리스트 조회
+   */
+  List<NotificationDto> getNotifications(Long memberId);
 
   /**
    * 서버의 이벤트를 클라이언트에게 보내는 메서드 (실제 알림 발생 시 사용)
@@ -16,5 +22,6 @@ public interface NotificationService {
    * 클라이언트가 구독을 위해 호출하는 메서드
    */
   SseEmitter subscribe(Long memberId);
+
 
 }

--- a/src/main/java/com/blog/som/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/blog/som/domain/notification/service/NotificationServiceImpl.java
@@ -36,11 +36,12 @@ public class NotificationServiceImpl implements NotificationService {
     List<NotificationEntity> list =
         notificationRepository.findTop100ByMemberOrderByCreatedAtDesc(member);
 
-    list.stream()
+    List<NotificationEntity> unreadList = notificationRepository.findByMemberAndReadAtIsNull(member);
+    unreadList.stream()
         .filter(n -> n.getReadAt() == null)
         .forEach(NotificationEntity::readNow);
 
-    notificationRepository.saveAll(list);
+    notificationRepository.saveAll(unreadList);
 
     return list.stream().map(NotificationDto::fromEntity).toList();
   }

--- a/src/main/java/com/blog/som/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/blog/som/domain/notification/service/NotificationServiceImpl.java
@@ -1,0 +1,73 @@
+package com.blog.som.domain.notification.service;
+
+import com.blog.som.domain.member.entity.MemberEntity;
+import com.blog.som.domain.notification.dto.NotificationCreateDto;
+import com.blog.som.domain.notification.dto.NotificationDto;
+import com.blog.som.domain.notification.entity.NotificationEntity;
+import com.blog.som.domain.notification.repository.EmitterRepository;
+import com.blog.som.domain.notification.repository.NotificationRepository;
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter.SseEventBuilder;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class NotificationServiceImpl implements NotificationService {
+
+  private static final Long EMITTER_DEFAULT_TIMEOUT = 1000 * 60 * 60L;
+
+  private final EmitterRepository emitterRepository;
+  private final NotificationRepository notificationRepository;
+
+  @Override
+  public NotificationDto notify(MemberEntity member, MemberEntity writer, NotificationCreateDto notificationCreateDto) {
+    NotificationEntity saved =
+        notificationRepository.save(NotificationCreateDto.toEntity(member, writer, notificationCreateDto));
+
+    this.sendToClient(member.getMemberId(), notificationCreateDto.getTitle());
+
+    return NotificationDto.fromEntity(saved);
+  }
+
+  @Override
+  public SseEmitter subscribe(Long memberId) {
+    //이미터 생성
+    SseEmitter emitter = new SseEmitter(EMITTER_DEFAULT_TIMEOUT);
+    emitterRepository.save(memberId, emitter);
+
+    //모든 데이터가 성공적으로 전송 된 상태 -> emitter 삭제
+    emitter.onCompletion(() -> emitterRepository.deleteById(memberId));
+    //타임아웃 되었을 때(지정 된 시간동안 아무 데이터도 전송되지 않았을 때) -> emitter 삭제
+    emitter.onTimeout(() -> emitterRepository.deleteById(memberId));
+
+    this.sendToClient(memberId, "EventStream Created");
+
+    return emitter;
+  }
+
+  private void sendToClient(Long id, Object data){
+    SseEmitter emitter = emitterRepository.getEmitter(id);
+
+    if(emitter != null){
+      try{
+        SseEventBuilder sse = SseEmitter.event()
+            .id(String.valueOf(id))
+            .name("data")
+            .data(data);
+        emitter.send(sse);
+
+      }
+      catch (IOException e){
+        emitterRepository.deleteById(id);
+        emitter.completeWithError(e);
+      }
+    }
+  }
+
+
+}

--- a/src/main/java/com/blog/som/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/blog/som/domain/notification/service/NotificationServiceImpl.java
@@ -1,11 +1,14 @@
 package com.blog.som.domain.notification.service;
 
 import com.blog.som.domain.member.entity.MemberEntity;
+import com.blog.som.domain.member.repository.MemberRepository;
 import com.blog.som.domain.notification.dto.NotificationCreateDto;
 import com.blog.som.domain.notification.dto.NotificationDto;
 import com.blog.som.domain.notification.entity.NotificationEntity;
 import com.blog.som.domain.notification.repository.EmitterRepository;
 import com.blog.som.domain.notification.repository.NotificationRepository;
+import com.blog.som.global.exception.ErrorCode;
+import com.blog.som.global.exception.custom.MemberException;
 import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -21,8 +24,20 @@ public class NotificationServiceImpl implements NotificationService {
 
   private static final Long EMITTER_DEFAULT_TIMEOUT = 1000 * 60 * 60L;
 
+  private final MemberRepository memberRepository;
   private final EmitterRepository emitterRepository;
   private final NotificationRepository notificationRepository;
+
+  @Override
+  public List<NotificationDto> getNotifications(Long memberId) {
+    MemberEntity member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+
+    List<NotificationEntity> list =
+        notificationRepository.findTop100ByMemberOrderByCreatedAtDesc(member);
+
+    return list.stream().map(NotificationDto::fromEntity).toList();
+  }
 
   @Override
   public NotificationDto notify(MemberEntity member, MemberEntity writer, NotificationCreateDto notificationCreateDto) {

--- a/src/main/java/com/blog/som/domain/notification/type/NotificationSituation.java
+++ b/src/main/java/com/blog/som/domain/notification/type/NotificationSituation.java
@@ -1,0 +1,14 @@
+package com.blog.som.domain.notification.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum NotificationSituation {
+  COMMENT,
+  FOLLOWED,
+  LIKES
+  ;
+
+}

--- a/src/main/java/com/blog/som/domain/post/mongo/service/MongoPostService.java
+++ b/src/main/java/com/blog/som/domain/post/mongo/service/MongoPostService.java
@@ -1,5 +1,6 @@
 package com.blog.som.domain.post.mongo.service;
 
+import com.blog.som.domain.likes.type.LikesStatus;
 import com.blog.som.domain.post.mongo.document.PostDocument;
 import com.blog.som.domain.post.mongo.respository.MongoPostRepository;
 import com.blog.som.global.exception.ErrorCode;
@@ -43,11 +44,11 @@ public class MongoPostService {
     log.info("[Elasticsearch PostDocument update profile_image] total amount={}", amount);
   }
 
-  public void updatePostDocumentLikes(boolean result, Long postId){
+  public void updatePostDocumentLikes(LikesStatus likesStatus, Long postId){
     PostDocument postDocument = mongoPostRepository.findByPostId(postId)
         .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
 
-    if(result){
+    if(LikesStatus.LIKES.equals(likesStatus)){
       postDocument.addLikes();
     }else{
       postDocument.minusLikes();


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요.  -->
### [알림 전송]
- SSE 이용
- 우선 client가 SseController에 있는 /subscribe/{memberId}로 구독 신청을 해야함.
- 구독 상태에서는 서버에서 알림을 보낼 때 마다 클라이언트측에서 확인할 수 있음.

### [알림 상황]
- 팔로우 받았을 때, 댓글 달렸을 때,  좋아요 받았을 때

### [알림 리스트]
- 최근 100개의 알림 내역을 List로 반환
- 모든 알림 읽음 처리

### [안읽은 알림 여부 조회]
- true or false 반환
---

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 

