### PR TITLE
[Refactor] BlogPostService MongoDB 제거 및 MyBatis 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,9 @@ dependencies {
     //jsoup
     implementation 'org.jsoup:jsoup:1.7.2'
 
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.0'
+
+
     //swagger
     implementation 'io.springfox:springfox-boot-starter:3.0.0'
     implementation 'io.springfox:springfox-swagger-ui:3.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 
+    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.2.0'
+
     //security
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation group: 'io.jsonwebtoken', name: 'jjwt', version:'0.9.1'

--- a/src/main/java/com/blog/som/SomApplication.java
+++ b/src/main/java/com/blog/som/SomApplication.java
@@ -4,7 +4,8 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class SomApplication {
+public class
+SomApplication {
 
   public static void main(String[] args) {
     SpringApplication.run(SomApplication.class, args);

--- a/src/main/java/com/blog/som/domain/blog/controller/BlogController.java
+++ b/src/main/java/com/blog/som/domain/blog/controller/BlogController.java
@@ -58,39 +58,19 @@ public class BlogController {
 
 
 
-  @ApiOperation("블로그 게시글 list 조회")
+  @ApiOperation(value = "블로그 게시글 list 조회", notes = "sort: latest/hot/tag/query")
   @GetMapping("/blog/{accountName}/posts")
   public ResponseEntity<BlogPostList> blogPosts(@PathVariable String accountName,
       @RequestParam(value = "sort", required = false, defaultValue = "latest") String sort,
-      @RequestParam(value = "tag", required = false, defaultValue = "") String tagName,
       @RequestParam(value = "q", required = false, defaultValue = "")String query,
       @RequestParam(value = "p",required = false, defaultValue = "1") int page){
     
     //accountName이 존재하는지 검증
     blogService.validateAccountName(accountName);
-    
-    //두가지 모두 query로 들어올 순 없음
-    if (StringUtils.hasText(tagName) && StringUtils.hasText(query)) {
-      throw new BlogException(ErrorCode.BLOG_POSTS_INVALID_QUERY);
-    }
 
-    //hot
-    if(sort.equals(SearchConstant.HOT)){
-      return ResponseEntity.ok(blogService.getAllBlogPostListBySortType(accountName, sort, page));
-    }
+    BlogPostList blogPostList = blogService.getBlogPosts(accountName, sort, query, page);
+    return ResponseEntity.ok(blogPostList);
 
-    //tag 검색
-    if(StringUtils.hasText(tagName)){
-      return ResponseEntity.ok(blogService.getBlogPostListByTag(accountName, tagName, page));
-    }
-
-    //query 검색
-    if(StringUtils.hasText(query)){
-      return ResponseEntity.ok(blogService.getBlogPostListByQuery(accountName, query, page));
-    }
-
-    //전체 검색
-    return ResponseEntity.ok(blogService.getAllBlogPostListBySortType(accountName, sort, page));
   }
 
 }

--- a/src/main/java/com/blog/som/domain/blog/controller/BlogController.java
+++ b/src/main/java/com/blog/som/domain/blog/controller/BlogController.java
@@ -53,7 +53,7 @@ public class BlogController {
 
     BlogTagListDto blogTags = blogService.getBlogTags(accountName);
 
-    return ResponseEntity.ok(blogTags);
+    return ResponseEntity.ok(blogService.getBlogTags(accountName));
   }
 
 
@@ -69,6 +69,7 @@ public class BlogController {
     blogService.validateAccountName(accountName);
 
     BlogPostList blogPostList = blogService.getBlogPosts(accountName, sort, query, page);
+
     return ResponseEntity.ok(blogPostList);
 
   }

--- a/src/main/java/com/blog/som/domain/blog/dto/BlogPostDto.java
+++ b/src/main/java/com/blog/som/domain/blog/dto/BlogPostDto.java
@@ -1,23 +1,22 @@
 package com.blog.som.domain.blog.dto;
 
+import com.blog.som.domain.mybatis.BlogPostWithTagString;
 import com.blog.som.domain.post.entity.PostEntity;
 import com.blog.som.domain.post.mongo.document.PostDocument;
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.List;
-import javax.persistence.EntityListeners;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-@EntityListeners(AuditingEntityListener.class)
 public class BlogPostDto {
 
   private Long postId;
@@ -59,6 +58,23 @@ public class BlogPostDto {
         .registeredAt(post.getRegisteredAt())
         .tags(tagList)
         .build();
+  }
+  public static BlogPostDto fromBlogPostWithTagString(BlogPostWithTagString blogPost) {
+    List<String> tagList = Arrays.stream(blogPost.getTags().split(", ")).toList();
+    return BlogPostDto.builder()
+            .postId(blogPost.getPostId())
+            .memberId(blogPost.getMemberId())
+            .profileImage(blogPost.getProfileImage())
+            .accountName(blogPost.getAccountName())
+            .title(blogPost.getTitle())
+            .thumbnail(blogPost.getThumbnail())
+            .introduction(blogPost.getIntroduction())
+            .likes(blogPost.getLikes())
+            .views(blogPost.getViews())
+            .comments(blogPost.getComments())
+            .registeredAt(blogPost.getRegisteredAt())
+            .tags(tagList)
+            .build();
   }
 
   public static BlogPostDto fromDocument(PostDocument postDocument) {

--- a/src/main/java/com/blog/som/domain/blog/repository/BlogPostRepository.java
+++ b/src/main/java/com/blog/som/domain/blog/repository/BlogPostRepository.java
@@ -1,0 +1,14 @@
+package com.blog.som.domain.blog.repository;
+
+
+import com.blog.som.domain.mybatis.BlogPostWithTagString;
+import com.blog.som.domain.post.entity.PostEntity;
+
+import java.util.List;
+
+public interface BlogPostRepository {
+
+    PostEntity findById(Long postId);
+    List<BlogPostWithTagString> findByMemberId(Long memberId, String sort, String value, int page, int pageSize);
+
+}

--- a/src/main/java/com/blog/som/domain/blog/service/BlogService.java
+++ b/src/main/java/com/blog/som/domain/blog/service/BlogService.java
@@ -30,6 +30,16 @@ public interface BlogService {
   FollowStatus getFollowStatus(Long memberId, String accountName);
 
   /**
+   * MyBatis -> 아래 3개를 이거 하나로 대체했음 (동적 쿼리)
+   * @param accountName
+   * @param sort
+   * @param value
+   * @param page
+   * @return
+   */
+  BlogPostList getBlogPosts(String accountName, String sort, String value, int page);
+
+  /**
    * 정렬 방식에 따른 postList 조회
    * - sort=latest(default) : 최신 순
    * - sort=hot : 조회수 순

--- a/src/main/java/com/blog/som/domain/blog/service/BlogServiceImpl.java
+++ b/src/main/java/com/blog/som/domain/blog/service/BlogServiceImpl.java
@@ -89,6 +89,7 @@ public class BlogServiceImpl implements BlogService {
     MemberEntity member = memberRepository.findByAccountName(accountName)
             .orElseThrow(() -> new BlogException(ErrorCode.BLOG_NOT_FOUND));
     log.info("value = {}", value);
+
     if(!StringUtils.hasText(value)){
       value = "";
     }
@@ -126,8 +127,8 @@ public class BlogServiceImpl implements BlogService {
         .orElseThrow(() -> new BlogException(ErrorCode.TAG_NOT_FOUND));
 
     PageRequest pageRequest =
-        PageRequest.of(page - 1, NumberConstant.DEFAULT_PAGE_SIZE,
-            Sort.by(SearchConstant.POST_CREATE_TIME).descending());
+            PageRequest.of(page - 1, NumberConstant.DEFAULT_PAGE_SIZE,
+                    Sort.by(SearchConstant.POST_CREATE_TIME).descending());
 
     Page<PostTagEntity> postTags = postTagRepository.findByMemberAndTag(member, tag, pageRequest);
 

--- a/src/main/java/com/blog/som/domain/blog/service/BlogServiceImpl.java
+++ b/src/main/java/com/blog/som/domain/blog/service/BlogServiceImpl.java
@@ -7,6 +7,8 @@ import com.blog.som.domain.blog.dto.BlogTagListDto;
 import com.blog.som.domain.follow.service.FollowService;
 import com.blog.som.domain.member.entity.MemberEntity;
 import com.blog.som.domain.member.repository.MemberRepository;
+import com.blog.som.domain.mybatis.BlogPostWithTagString;
+import com.blog.som.domain.mybatis.MyBatisBlogPostRepository;
 import com.blog.som.domain.post.entity.PostEntity;
 import com.blog.som.domain.post.repository.PostRepository;
 import com.blog.som.domain.tag.dto.TagDto;
@@ -26,12 +28,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 @Slf4j
 @RequiredArgsConstructor
 @Transactional
-//@Service
+@Service
 public class BlogServiceImpl implements BlogService {
 
   private final MemberRepository memberRepository;
@@ -39,6 +43,7 @@ public class BlogServiceImpl implements BlogService {
   private final TagRepository tagRepository;
   private final PostTagRepository postTagRepository;
   private final FollowService followService;
+  private final MyBatisBlogPostRepository myBatisBlogPostRepository;
 
   @Override
   public BlogMemberDto getBlogMember(String accountName) {
@@ -51,12 +56,12 @@ public class BlogServiceImpl implements BlogService {
   @Override
   public BlogTagListDto getBlogTags(String accountName) {
     MemberEntity member = memberRepository.findByAccountName(accountName)
-        .orElseThrow(() -> new BlogException(ErrorCode.BLOG_NOT_FOUND));
+            .orElseThrow(() -> new BlogException(ErrorCode.BLOG_NOT_FOUND));
 
     List<TagDto> tagDtoList = tagRepository.findAllByMember(member)
-        .stream()
-        .map(TagDto::fromEntity)
-        .toList();
+            .stream()
+            .map(TagDto::fromEntity)
+            .toList();
 
     int count = postRepository.countByMember(member);
 
@@ -80,26 +85,36 @@ public class BlogServiceImpl implements BlogService {
   }
 
   @Override
+  public BlogPostList getBlogPosts(String accountName, String sort, String value, int page){
+    MemberEntity member = memberRepository.findByAccountName(accountName)
+            .orElseThrow(() -> new BlogException(ErrorCode.BLOG_NOT_FOUND));
+    log.info("value = {}", value);
+    if(!StringUtils.hasText(value)){
+      value = "";
+    }
+    //sort는 latest / hot / views / tag / query
+    int pageStart = (page - 1) * NumberConstant.DEFAULT_PAGE_SIZE;
+
+    List<BlogPostWithTagString> findPostList = myBatisBlogPostRepository.findByMemberId(member.getMemberId(), sort, value, pageStart, NumberConstant.DEFAULT_PAGE_SIZE);
+    List<BlogPostDto> list = findPostList.stream().map(BlogPostDto::fromBlogPostWithTagString).toList();
+
+    return new BlogPostList(PageDto.fromPageConstants(findPostList.size(), page, NumberConstant.DEFAULT_PAGE_SIZE), list);
+  }
+
+  @Override
   public BlogPostList getAllBlogPostListBySortType(String accountName, String sort, int page) {
     MemberEntity member = memberRepository.findByAccountName(accountName)
         .orElseThrow(() -> new BlogException(ErrorCode.BLOG_NOT_FOUND));
 
     String sortBy = SearchConstant.REGISTERED_AT;
     if (sort.equals(SearchConstant.HOT)) {
-      sortBy = SearchConstant.VIEWS;
+      sortBy = "views";
     }
+    List<BlogPostWithTagString> findPostList = myBatisBlogPostRepository.findByMemberId(member.getMemberId(), sortBy, "",(page - 1) * NumberConstant.DEFAULT_PAGE_SIZE, NumberConstant.DEFAULT_PAGE_SIZE);
+    List<BlogPostDto> list = findPostList.stream().map(BlogPostDto::fromBlogPostWithTagString).toList();
 
 
-    Page<PostEntity> posts =
-        postRepository.findByMember(member,
-            PageRequest.of(page - 1, NumberConstant.DEFAULT_PAGE_SIZE, Sort.by(sortBy).descending()));
-
-    List<BlogPostDto> blogPostList =
-        posts.getContent().stream()
-            .map(this::getBlogPostDtoFromPostEntity)
-            .toList();
-
-    return new BlogPostList(PageDto.fromPostEntityPage(posts), blogPostList);
+    return new BlogPostList(PageDto.fromPageConstants(findPostList.size(), page, NumberConstant.DEFAULT_PAGE_SIZE), list);
   }
 
   @Override

--- a/src/main/java/com/blog/som/domain/blog/service/MongoBlogService.java
+++ b/src/main/java/com/blog/som/domain/blog/service/MongoBlogService.java
@@ -27,7 +27,7 @@ import org.springframework.stereotype.Service;
 
 @Slf4j
 @RequiredArgsConstructor
-@Service
+//@Service
 public class MongoBlogService implements BlogService {
 
   private final MemberRepository memberRepository;
@@ -75,11 +75,16 @@ public class MongoBlogService implements BlogService {
   }
 
   @Override
+  public BlogPostList getBlogPosts(String accountName, String sort, String value, int page) {
+    return null;
+  }
+
+  @Override
   public BlogPostList getAllBlogPostListBySortType(String accountName, String sort, int page) {
     String sortBy = SearchConstant.REGISTERED_AT;
 
     if (sort.equals(SearchConstant.HOT)) {
-      sortBy = SearchConstant.VIEWS;
+      sortBy = "views";
     }
     PageRequest pageRequest = PageRequest.of(page - 1, NumberConstant.DEFAULT_PAGE_SIZE, Sort.by(sortBy).descending());
 

--- a/src/main/java/com/blog/som/domain/mybatis/BlogPostMapper.java
+++ b/src/main/java/com/blog/som/domain/mybatis/BlogPostMapper.java
@@ -1,0 +1,17 @@
+package com.blog.som.domain.mybatis;
+
+import com.blog.som.domain.post.entity.PostEntity;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface BlogPostMapper {
+
+    PostEntity findById(Long postId);
+
+    List<BlogPostWithTagString> findPostsByMemberId(
+            @Param("memberId") Long memberId,@Param("sort") String sort, @Param("value") String value, @Param("pageStart") int pageStart, @Param("pageSize") int pageSize);
+
+}

--- a/src/main/java/com/blog/som/domain/mybatis/BlogPostWithTagString.java
+++ b/src/main/java/com/blog/som/domain/mybatis/BlogPostWithTagString.java
@@ -1,0 +1,26 @@
+package com.blog.som.domain.mybatis;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@Builder
+public class BlogPostWithTagString {
+        private Long postId;
+        private Long memberId;
+        private String profileImage;
+        private String accountName;
+        private String title;
+        private String thumbnail;
+        private String introduction;
+        private int likes;
+        private int views;
+        private int comments;
+        private LocalDateTime registeredAt;
+        private String tags; // 콤마로 구분된 태그 문자열
+}

--- a/src/main/java/com/blog/som/domain/mybatis/MyBatisBlogPostRepository.java
+++ b/src/main/java/com/blog/som/domain/mybatis/MyBatisBlogPostRepository.java
@@ -1,0 +1,30 @@
+package com.blog.som.domain.mybatis;
+
+import com.blog.som.domain.blog.repository.BlogPostRepository;
+import com.blog.som.domain.post.entity.PostEntity;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class MyBatisBlogPostRepository implements BlogPostRepository {
+
+    private final BlogPostMapper blogPostMapper;
+
+    @Override
+    public PostEntity findById(Long postId) {
+        return blogPostMapper.findById(postId);
+    }
+
+    @Override
+    public List<BlogPostWithTagString> findByMemberId(Long memberId, String sort, String value, int pageStart, int pageSize) {
+        List<BlogPostWithTagString> findList = blogPostMapper.findPostsByMemberId(memberId, sort, value, pageStart, pageSize);
+        log.info("find Data : {}", findList);
+        return findList;
+    }
+
+}

--- a/src/main/java/com/blog/som/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/blog/som/domain/post/repository/PostRepository.java
@@ -15,7 +15,5 @@ public interface PostRepository extends JpaRepository<PostEntity, Long> {
   Page<PostEntity> findByMemberAndTitleContainingOrIntroductionContaining(
       MemberEntity member, String title, String introduction, Pageable pageable);
 
-  Page<PostEntity> findByTitleContainingOrIntroductionContaining(String title, String introduction, Pageable pageable);
-
   int countByMember(MemberEntity member);
 }

--- a/src/main/java/com/blog/som/domain/tag/repository/PostTagRepository.java
+++ b/src/main/java/com/blog/som/domain/tag/repository/PostTagRepository.java
@@ -5,15 +5,23 @@ import com.blog.som.domain.post.entity.PostEntity;
 import com.blog.som.domain.tag.entity.PostTagEntity;
 import com.blog.som.domain.tag.entity.TagEntity;
 import java.util.List;
+
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostTagRepository extends JpaRepository<PostTagEntity, Long> {
 
   List<PostTagEntity> findAllByPost(PostEntity post);
+
+  @Query("SELECT t.tagName from post_tag pt " +
+          "JOIN tag t on pt.tag.tagId = t.tagId " +
+          "where pt.post = :post")
+  List<String> findPostTagNamesByPost(@Param("post") PostEntity post);
 
   Page<PostTagEntity> findByMemberAndTag(MemberEntity member, TagEntity tag, Pageable pageable);
 }

--- a/src/main/java/com/blog/som/domain/tag/repository/PostTagRepository.java
+++ b/src/main/java/com/blog/som/domain/tag/repository/PostTagRepository.java
@@ -24,4 +24,5 @@ public interface PostTagRepository extends JpaRepository<PostTagEntity, Long> {
   List<String> findPostTagNamesByPost(@Param("post") PostEntity post);
 
   Page<PostTagEntity> findByMemberAndTag(MemberEntity member, TagEntity tag, Pageable pageable);
+
 }

--- a/src/main/java/com/blog/som/domain/test/DataCreationController.java
+++ b/src/main/java/com/blog/som/domain/test/DataCreationController.java
@@ -1,0 +1,99 @@
+package com.blog.som.domain.test;
+
+import com.blog.som.domain.member.entity.MemberEntity;
+import com.blog.som.domain.member.repository.MemberRepository;
+import com.blog.som.domain.post.entity.PostEntity;
+import com.blog.som.domain.post.repository.PostRepository;
+import com.blog.som.domain.tag.entity.PostTagEntity;
+import com.blog.som.domain.tag.entity.TagEntity;
+import com.blog.som.domain.tag.repository.PostTagRepository;
+import com.blog.som.domain.tag.repository.TagRepository;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+/**
+ * 위에서부터 테스트용 게시글, tag, post_tag를 세팅할 수 있다.
+ * jsonplaceholder사이트의 데이터를 사용한다.
+ */
+@RequiredArgsConstructor
+@RestController
+public class DataCreationController {
+
+    private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
+    private final TagRepository tagRepository;
+    private final PostTagRepository postTagRepository;
+
+
+    @ApiOperation("jsonplaceholder에서 post 임시 데이터 저장")
+    @GetMapping("/test/post")
+    public ResponseEntity<?> savePosts(){
+        RestAPI restAPI = new RestAPI();
+
+        MemberEntity member = memberRepository.findById(1L).get();
+
+        List<PostEntity> saveList = new ArrayList<>();
+        List<Map<String, Object>> posts = restAPI.getPosts();
+        for (Map<String, Object> post : posts) {
+            PostEntity postEntity = PostEntity.builder()
+                    .member(member)
+                    .title(post.get("title").toString())
+                    .content(post.get("body").toString())
+                    .thumbnail(restAPI.getRandomThumbnail())
+                    .build();
+
+            postEntity.setIntroduction("test introduction: " + postEntity.getContent().substring(0, 10));
+            saveList.add(postEntity);
+        }
+        postRepository.saveAll(saveList);
+        return ResponseEntity.ok("complete");
+    }
+
+    @ApiOperation("tag 세팅")
+    @GetMapping("/test/tags")
+    public ResponseEntity<?> saveTags(){
+        MemberEntity member = memberRepository.findById(1L).get();
+        List<TagEntity> saveList = new ArrayList<>();
+        for(int i = 1; i <= 10; i++){
+           saveList.add(TagEntity.builder()
+                    .member(member)
+                    .tagName("test_tag_" + i)
+                    .build());
+        }
+        tagRepository.saveAll(saveList);
+        return ResponseEntity.ok("complete");
+    }
+
+    @Transactional
+    @ApiOperation("post tag 세팅")
+    @GetMapping("/test/posttags")
+    public ResponseEntity<?> savePostTags(){
+        MemberEntity member = memberRepository.findById(1L).get();
+        List<PostTagEntity> saveList = new ArrayList<>();
+        List<TagEntity> tags = tagRepository.findAll();
+        List<PostEntity> postList = postRepository.findAll();
+        for (PostEntity post : postList) {
+            int n = new Random().nextInt(10);
+            saveList.add(PostTagEntity.builder()
+                    .post(post)
+                    .tag(tags.get(n))
+                    .member(member)
+                    .postCreatedTime(post.getRegisteredAt())
+                    .build());
+        }
+        postTagRepository.saveAll(saveList);
+        return ResponseEntity.ok("complete");
+    }
+
+
+}

--- a/src/main/java/com/blog/som/domain/test/RestAPI.java
+++ b/src/main/java/com/blog/som/domain/test/RestAPI.java
@@ -1,0 +1,63 @@
+package com.blog.som.domain.test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+public class RestAPI {
+
+    private String getResponseJson(String url){
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.CONTENT_TYPE, "application/json");
+
+        HttpEntity<Object> request = new HttpEntity<>(headers);
+
+
+
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, request, String.class);
+        return response.getBody();
+    }
+
+    public List<Map<String, Object>> getPosts(){
+        String url = "https://jsonplaceholder.typicode.com/posts";
+
+        String responseJson = getResponseJson(url);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        List<Map<String, Object>> resultList;
+        try {
+            resultList = objectMapper.readValue(responseJson, List.class);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+
+        return resultList;
+    }
+
+    public String getRandomThumbnail(){
+        int num = new Random().nextInt(5000 + 1);
+        String url = "https://jsonplaceholder.typicode.com/photos/" + num;
+
+        String responseJson = getResponseJson(url);
+        System.out.println(responseJson);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        Map<String, Object> result;
+        try {
+            result = objectMapper.readValue(responseJson, Map.class);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+
+        return result.get("thumbnailUrl").toString();
+    }
+}

--- a/src/main/java/com/blog/som/global/constant/SearchConstant.java
+++ b/src/main/java/com/blog/som/global/constant/SearchConstant.java
@@ -6,8 +6,9 @@ public class SearchConstant {
 
   public static final String HOT = "hot";
   public static final String REGISTERED_AT = "registeredAt";
-  public static final String VIEWS = "views";
+  public static final String TAG = "tag";
+  public static final String QUERY = "query";
   public static final String POST_CREATE_TIME = "postCreatedTime";
-
+  public static final String VIEWS = "views";
 
 }

--- a/src/main/java/com/blog/som/global/dto/PageDto.java
+++ b/src/main/java/com/blog/som/global/dto/PageDto.java
@@ -23,6 +23,16 @@ public class PageDto {
   private int totalElement; //전체 데이터 개수
   private int totalPages; //전체 페이지 개수
 
+  public static PageDto fromPageConstants(int dataSize, int page, int pageSize){
+    return PageDto.builder()
+            .currentPage(page)
+            .currentElements(dataSize)
+            .pageSize(pageSize)
+            .totalElement(100)
+            .totalPages(100)
+            .build();
+  }
+
   public static PageDto fromPostEntityPage(Page<PostEntity> page) {
     return PageDto.builder()
         .currentPage(page.getNumber() + 1)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,10 +10,17 @@ spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
 # jpa
 spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=update
-spring.jpa.properties.hibernate.format_sql=true
+#spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.hibernate.use-new-id-generator-mappings=false
 spring.jpa.defer-datasource-initialization=true
 spring.jpa.open-in-view=true
+
+#mybatis
+mybatis.type-aliases-package=com.blog.som.domain
+mybatis.mapper-locations=classpath:mapper/*.xml
+mybatis.configuration.map-underscore-to-camel-case=true
+logging.level.org.mybatis=info
+logging.level.mapper=DEBUG
 
 # mongodb
 spring.data.mongodb.authentication-database=admin

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,7 +10,7 @@ spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
 # jpa
 spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=update
-#spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.hibernate.use-new-id-generator-mappings=false
 spring.jpa.defer-datasource-initialization=true
 spring.jpa.open-in-view=true

--- a/src/main/resources/mapper/BlogPostMapper.xml
+++ b/src/main/resources/mapper/BlogPostMapper.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.blog.som.domain.mybatis.BlogPostMapper">
+
+    <!-- sql 관련 코드  -->
+
+    <select id="findById" resultType="PostEntity">
+        SELECT *
+        FROM post
+        where post_id = #{postId}
+    </select>
+
+    <select id="findPostsByMemberId" resultType="BlogPostWithTagString">
+        SELECT
+            *
+        FROM
+        (SELECT
+            p.post_id AS postId,
+            p.member_id AS memberId,
+            m.profile_image AS profileImage,
+            m.account_name AS accountName,
+            p.title AS title,
+            p.thumbnail AS thumbnail,
+            p.introduction AS introduction,
+            p.likes AS likes,
+            p.views AS views,
+            p.comments AS comments,
+            p.registered_at AS registeredAt,
+            GROUP_CONCAT(t.tag_name ORDER BY t.tag_name ASC SEPARATOR ', ') AS tags
+        FROM
+            post p
+                JOIN
+            member m
+            ON p.member_id = m.member_id
+                LEFT JOIN
+            post_tag pt
+            ON p.post_id = pt.post_id
+                LEFT JOIN
+            tag t
+            ON pt.tag_id = t.tag_id
+        WHERE
+            p.member_id = #{memberId}
+        GROUP BY p.post_id) bp
+        <where>
+            <if test="value != null and value != '' and sort == 'tag'">
+                bp.tags LIKE CONCAT('%', #{value}, '%')
+            </if>
+            <if test="value != null and value != '' and sort == 'query'">
+                bp.title LIKE CONCAT('%', #{value}, '%') OR bp.introduction LIKE CONCAT('%', #{value}, '%')
+            </if>
+        </where>
+        <if test="sort == 'hot'">
+            ORDER BY bp.views DESC
+        </if>
+        <if test="sort == 'tag' or sort == 'latest' or sort == 'query'">
+            ORDER BY bp.registeredAt DESC
+        </if>
+        LIMIT ${pageStart}, ${pageSize}
+    </select>
+
+</mapper>

--- a/src/test/java/com/blog/som/Test.java
+++ b/src/test/java/com/blog/som/Test.java
@@ -1,0 +1,13 @@
+package com.blog.som;
+
+import com.blog.som.domain.test.RestAPI;
+
+public class Test {
+    public static void main(String[] args) {
+        RestAPI restAPI = new RestAPI();
+        //restAPI.getPosts();
+
+        String randomPhoto = restAPI.getRandomThumbnail();
+        System.out.println(randomPhoto);
+    }
+}

--- a/src/test/java/com/blog/som/domain/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/blog/som/domain/post/repository/PostRepositoryTest.java
@@ -1,0 +1,29 @@
+package com.blog.som.domain.post.repository;
+
+import com.blog.som.domain.member.repository.MemberRepository;
+import com.blog.som.domain.mybatis.BlogPostWithTagString;
+import com.blog.som.domain.mybatis.MyBatisBlogPostRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+@SpringBootTest
+class PostRepositoryTest {
+
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    PostRepository postRepository;
+    @Autowired
+    MyBatisBlogPostRepository myBatisBlogPostRepository;
+
+    @Test
+    void findByMember() {
+        List<BlogPostWithTagString> byMemberId = myBatisBlogPostRepository.findByMemberId(1L, "hot", "", 0, 10);
+        for (BlogPostWithTagString blogPostWithTagString : byMemberId) {
+            System.out.println(blogPostWithTagString);
+        }
+    }
+}

--- a/src/test/java/com/blog/som/domain/post/service/PostServiceImplTest.java
+++ b/src/test/java/com/blog/som/domain/post/service/PostServiceImplTest.java
@@ -108,7 +108,6 @@ class PostServiceImplTest {
       PostDto result = postService.writePost(request, 1L);
 
       //then
-      verify(mongoPostRepository, times(1)).save(PostDocument.fromEntity(post, tagList));
       assertThat(result.getTitle()).isEqualTo(request.getTitle());
       assertThat(result.getContent()).isEqualTo(request.getContent());
       assertThat(result.getTags()).containsAll(tagList);
@@ -139,7 +138,7 @@ class PostServiceImplTest {
   class GetPost {
 
     @Test
-    @DisplayName("성공 : 조회수 증가, PostDocument 존재")
+    @DisplayName("성공 : 조회수 증가")
     void getPost_PostDocument_exists() {
       MemberEntity member = EntityCreator.createMember(1L);
       PostEntity post = EntityCreator.createPost(10L, member);
@@ -148,15 +147,11 @@ class PostServiceImplTest {
       PostTagEntity postTag1 = EntityCreator.createPostTag(1000L, post, tag1);
       PostTagEntity postTag2 = EntityCreator.createPostTag(1001L, post, tag2);
 
-      PostDocument PostDocument = EntityCreator.createPostDocument(post, new ArrayList<>(Arrays.asList(TAG_1, TAG_2)));
-
       String userAgent = "CHROME/123";
 
       //given
       when(postRepository.findById(10L))
           .thenReturn(Optional.of(post));
-      when(mongoPostRepository.findByPostId(10L))
-          .thenReturn(Optional.of(PostDocument));
       when(cacheRepository.canAddView(userAgent, 10L))
           .thenReturn(true);
 
@@ -164,50 +159,13 @@ class PostServiceImplTest {
       PostDto postDto = postService.getPost(10L, userAgent);
 
       //then
-      verify(postRepository, times(1)).save(post);
-      verify(mongoPostRepository, times(1)).save(PostDocument);
       assertThat(postDto.getPostId()).isEqualTo(post.getPostId());
       assertThat(postDto.getTitle()).isEqualTo(post.getTitle());
     }
 
-    @Test
-    @DisplayName("성공 : 조회수 증가, PostDocument X")
-    void getPost_PostDocument_doesnt_exists() {
-      MemberEntity member = EntityCreator.createMember(1L);
-      PostEntity post = EntityCreator.createPost(10L, member);
-      TagEntity tag1 = EntityCreator.createTag(100L, TAG_1, member);
-      TagEntity tag2 = EntityCreator.createTag(101L, TAG_2, member);
-      PostTagEntity postTag1 = EntityCreator.createPostTag(1000L, post, tag1);
-      PostTagEntity postTag2 = EntityCreator.createPostTag(1001L, post, tag2);
-
-      PostDocument PostDocument = EntityCreator.createPostDocument(post, new ArrayList<>(Arrays.asList(TAG_1, TAG_2)));
-
-      String userAgent = "CHROME/123";
-
-      //given
-      when(postRepository.findById(10L))
-          .thenReturn(Optional.of(post));
-      when(mongoPostRepository.findByPostId(10L))
-          .thenReturn(Optional.empty());
-      when(postTagRepository.findAllByPost(post))
-          .thenReturn(new ArrayList<>(Arrays.asList(postTag1, postTag2)));
-      when(mongoPostRepository.save(PostDocument.fromEntity(post, new ArrayList<>(Arrays.asList(TAG_1, TAG_2)))))
-          .thenReturn(PostDocument);
-      when(cacheRepository.canAddView(userAgent, 10L))
-          .thenReturn(true);
-
-      //when
-      PostDto postDto = postService.getPost(10L, userAgent);
-
-      //then
-      verify(postRepository, times(1)).save(post);
-      verify(mongoPostRepository, times(2)).save(PostDocument);
-      assertThat(postDto.getPostId()).isEqualTo(post.getPostId());
-      assertThat(postDto.getTitle()).isEqualTo(post.getTitle());
-    }
 
     @Test
-    @DisplayName("성공 : 조회수 증가 X, PostDocument 존재")
+    @DisplayName("성공 : 조회수 증가 X")
     void getPost_never_add_view_PostDocument_exists() {
       MemberEntity member = EntityCreator.createMember(1L);
       PostEntity post = EntityCreator.createPost(10L, member);
@@ -216,15 +174,11 @@ class PostServiceImplTest {
       PostTagEntity postTag1 = EntityCreator.createPostTag(1000L, post, tag1);
       PostTagEntity postTag2 = EntityCreator.createPostTag(1001L, post, tag2);
 
-      PostDocument PostDocument = EntityCreator.createPostDocument(post, new ArrayList<>(Arrays.asList(TAG_1, TAG_2)));
-
       String userAgent = "CHROME/123";
 
       //given
       when(postRepository.findById(10L))
           .thenReturn(Optional.of(post));
-      when(mongoPostRepository.findByPostId(10L))
-          .thenReturn(Optional.of(PostDocument));
       when(cacheRepository.canAddView(userAgent, 10L))
           .thenReturn(false);
 
@@ -232,42 +186,6 @@ class PostServiceImplTest {
       PostDto postDto = postService.getPost(10L, userAgent);
 
       //then
-      verify(postRepository, never()).save(post);
-      verify(mongoPostRepository, never()).save(PostDocument);
-      assertThat(postDto.getPostId()).isEqualTo(post.getPostId());
-      assertThat(postDto.getTitle()).isEqualTo(post.getTitle());
-    }
-
-    @Test
-    @DisplayName("성공 : 조회수 증가 X, PostDocument X")
-    void getPost_never_add_view_PostDocument_doesnt_exists() {
-      MemberEntity member = EntityCreator.createMember(1L);
-      PostEntity post = EntityCreator.createPost(10L, member);
-      TagEntity tag1 = EntityCreator.createTag(100L, TAG_1, member);
-      TagEntity tag2 = EntityCreator.createTag(101L, TAG_2, member);
-      PostTagEntity postTag1 = EntityCreator.createPostTag(1000L, post, tag1);
-      PostTagEntity postTag2 = EntityCreator.createPostTag(1001L, post, tag2);
-
-      PostDocument PostDocument = EntityCreator.createPostDocument(post, new ArrayList<>(Arrays.asList(TAG_1, TAG_2)));
-
-      String userAgent = "CHROME/123";
-
-      //given
-      when(postRepository.findById(10L))
-          .thenReturn(Optional.of(post));
-      when(mongoPostRepository.findByPostId(10L))
-          .thenReturn(Optional.empty());
-      when(postTagRepository.findAllByPost(post))
-          .thenReturn(new ArrayList<>(Arrays.asList(postTag1, postTag2)));
-      when(cacheRepository.canAddView(userAgent, 10L))
-          .thenReturn(false);
-
-      //when
-      PostDto postDto = postService.getPost(10L, userAgent);
-
-      //then
-      verify(postRepository, never()).save(post);
-      verify(mongoPostRepository, times(1)).save(PostDocument);
       assertThat(postDto.getPostId()).isEqualTo(post.getPostId());
       assertThat(postDto.getTitle()).isEqualTo(post.getTitle());
     }
@@ -338,13 +256,9 @@ class PostServiceImplTest {
       PostDto postDto = postService.editPost(request, 10L, 1L);
 
       //then
-      verify(postRepository, times(1)).save(post);
       verify(postTagRepository, never()).delete(any(PostTagEntity.class));
       verify(tagRepository, never()).findByTagNameAndMember(TAG_1, member);
       verify(tagRepository, never()).findByTagNameAndMember(TAG_2, member);
-      verify(mongoPostRepository, times(1)).deleteByPostId(post.getPostId());
-      verify(mongoPostRepository, times(1)).save(PostDocument.fromEntity(post, list));
-
 
       assertThat(postDto.getTags()).containsAll(list);
       assertThat(postDto.getTitle()).isEqualTo(request.getTitle());
@@ -388,15 +302,11 @@ class PostServiceImplTest {
       PostDto postDto = postService.editPost(request, 10L, 1L);
 
       //then
-      verify(postRepository, times(1)).save(post);
       verify(postTagRepository, times(1)).delete(postTag2);
       verify(tagRepository, times(1)).delete(tag2);
       //handleNewTags
       verify(tagRepository, times(1)).save(any(TagEntity.class));
       verify(postTagRepository, times(1)).save(any(PostTagEntity.class));
-      //elasticsearch
-      verify(mongoPostRepository, times(1)).deleteByPostId(post.getPostId());
-      verify(mongoPostRepository, times(1)).save(PostDocument.fromEntity(post, list));
 
       assertThat(postDto.getTags()).containsAll(list);
       assertThat(postDto.getTitle()).isEqualTo(request.getTitle());
@@ -440,14 +350,10 @@ class PostServiceImplTest {
       PostDto postDto = postService.editPost(request, 10L, 1L);
 
       //then
-      verify(postRepository, times(1)).save(post);
       verify(postTagRepository, times(1)).delete(postTag2);
       verify(tagRepository, never()).delete(tag2);
       verify(tagRepository, times(2)).save(any(TagEntity.class));
       verify(postTagRepository, times(1)).save(any(PostTagEntity.class));
-      //elasticsearch
-      verify(mongoPostRepository, times(1)).deleteByPostId(post.getPostId());
-      verify(mongoPostRepository, times(1)).save(PostDocument.fromEntity(post, list));
 
       assertThat(postDto.getTags()).containsAll(list);
       assertThat(postDto.getTitle()).isEqualTo(request.getTitle());
@@ -524,8 +430,6 @@ class PostServiceImplTest {
       verify(postTagRepository, times(1)).delete(postTag1);
       verify(tagRepository, times(1)).delete(tag1);
       verify(postRepository, times(1)).delete(post);
-      //elasticsearch
-      verify(mongoPostRepository, times(1)).deleteByPostId(post.getPostId());
 
       assertThat(response.getPostId()).isEqualTo(10L);
       assertThat(response.getPostTitle()).isEqualTo(post.getTitle());
@@ -557,8 +461,6 @@ class PostServiceImplTest {
       verify(tagRepository, never()).delete(tag1);
       verify(tagRepository, times(1)).save(tag1);
       verify(postRepository, times(1)).delete(post);
-      //elasticsearch
-      verify(mongoPostRepository, times(1)).deleteByPostId(post.getPostId());
 
       assertThat(response.getPostId()).isEqualTo(10L);
       assertThat(response.getPostTitle()).isEqualTo(post.getTitle());

--- a/src/test/java/com/blog/som/domain/tag/repository/PostTagRepositoryTest.java
+++ b/src/test/java/com/blog/som/domain/tag/repository/PostTagRepositoryTest.java
@@ -1,0 +1,28 @@
+package com.blog.som.domain.tag.repository;
+
+import com.blog.som.domain.post.entity.PostEntity;
+import com.blog.som.domain.post.repository.PostRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class PostTagRepositoryTest {
+
+    @Autowired
+    PostTagRepository postTagRepository;
+
+    @Autowired
+    PostRepository postRepository;
+
+    @Test
+    void findPostTagNamesByPost() {
+        PostEntity post = postRepository.findById(3L).get();
+        List<String> list = postTagRepository.findPostTagNamesByPost(post);
+        System.out.println(list);
+    }
+}


### PR DESCRIPTION
### 변경사항
- Blog API 수정
- MongoDB 제거, 일부 동적 쿼리 MyBatis 사용  

### AS-IS
- C: MariaDB에 저장 후 Mongo에 복제
- R: MongoDB에서 조회
- U: MariaDB, MongoDB에서 둘다 수정
- D: Maria, Mongo 둘 다에서 삭제

### TO-BE
- MongoDB 사용 x
- RDB에만 접근해서 데이터를 관리하도록 수정
- JPA에서 테이블 4건을 조회하던 로직을 MyBatis를 이용해서 처리하도록 수정
- 쿼리 14건 -> 3건으로 감소


#### link
[https://innovation123.tistory.com/245](https://innovation123.tistory.com/245)


